### PR TITLE
Updating follow-redirects package. 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2385,9 +2385,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
-      "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==",
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
       "funding": [
         {
           "type": "individual",
@@ -7525,9 +7525,9 @@
       "version": "1.1.0"
     },
     "follow-redirects": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
-      "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A=="
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
     },
     "form-data": {
       "version": "3.0.1",


### PR DESCRIPTION
**Updating follow-redirects package.**
* * *

**JIRA Ticket**: None

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
  * [Dependabot Alert](https://github.com/harvard-lts/mps-embed/security/dependabot/package-lock.json/follow-redirects/open)

# What does this Pull Request do?
This upgrades the follow-redirects package to 1.14.7, resolving the high severity alert found by dependabot.

# How should this be tested?

A description of what steps someone could take to:
* Build the container off of the `main` branch
* SSH into the container: `docker exec -it mps-embed bash`
* Run `npm audit` and notice it is displaying the same alert as dependabot
* Take down and destroy the container and switch to the `update-follow-redirects` branch
* Build the container
* SSH into the container
* Run `npm audit` and notice that the alert is resolved.
* Confirm that the MPS Embed application works as it did previously.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz 