### PR TITLE
Adding removePager to viewerUrl.

### DIFF
--- a/controllers/http.ctrl.js
+++ b/controllers/http.ctrl.js
@@ -100,6 +100,37 @@ httpCtrl.getItem = async (recordIdentifier) => {
         }
       }
       return data;
-  };  
+  };
+
+  httpCtrl.removePager = async (iiifManifest) => {
+    let result = {};
+    let response;
+    let viewingHint = '';
+    let removePager = '';
+
+    try {
+      response = await axios.get(iiifManifest);
+    } catch(e) {
+      const errorMsg = e.response && e.response.data ? e.response.data : e.code;
+      console.log(errorMsg);
+      result.error = errorMsg;
+      result.status = result.error.status || 500;
+      return result;
+    }
+
+    result.status = response && response.status || 500;
+    result.data = response && response.data || {};
+    
+    if (result.data.sequences !== null) {
+      if (result.data.sequences[0].hasOwnProperty('viewingHint')) {
+        viewingHint = result.data.sequences[0].viewingHint;
+        if (viewingHint == 'individuals') {
+          removePager="removePager=1";
+        }
+      }
+    }
+
+    return removePager;
+  };
 
 module.exports = httpCtrl;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ version: '3.7'
 services:
 
   app:
-    image: registry.lts.harvard.edu/lts/mps-embed:0.0.7
+    image: registry.lts.harvard.edu/lts/mps-embed:0.0.8
     build:
       context: ./
       dockerfile: Dockerfile

--- a/routes/api.js
+++ b/routes/api.js
@@ -7,24 +7,30 @@ const httpCtrl = require('../controllers/http.ctrl');
 router.get('/', async function(req, res, next) {
   
   let data = '';
+  let record = '';
+  let viewerUrl = '';
+  let iiifManifest = '';
+  let removePager = '';
   let viewerServer = process.env.VIEWER_SERVER;
   let recordIdentifier = req.query.recordIdentifier;
 
   record = await httpCtrl.getItem(recordIdentifier);
   data = await httpCtrl.getData(record);
-  viewer_url = "https://"+viewerServer+"/viewer/"+data.uriType+"/"+data.drsFileId;
-  
+  iiifManifest = "https://iiif.lib.harvard.edu/manifests/"+data.uriType+":"+data.drsFileId;
+  removePager = await httpCtrl.removePager(iiifManifest);
+  viewerUrl = "https://"+viewerServer+"/viewer/"+data.uriType+"/"+data.drsFileId+"?"+removePager;
+
   res.json( 
     {
       type: data.uriType,
       version:"1.0",
       provider_name:"MPS Embed",
       title:data.title,
-      iiif_manifest:"https://iiif.lib.harvard.edu/manifests/"+data.uriType+":"+data.drsFileId,
-      viewer_url: viewer_url,
+      iiif_manifest:iiifManifest,
+      viewer_url: viewerUrl,
       height:400,
       width:null,
-      html:"\u003ciframe src=\""+viewer_url+"\" height=\"700px\" width=\"1200px\" title=\""+data.title+"\" frameborder=\"0\" marginwidth=\"0\" marginheight=\"0\" scrolling=\"no\" allowfullscreen\u003e\u003c/iframe\u003e\n"
+      html:"\u003ciframe src=\""+viewerUrl+"\" height=\"700px\" width=\"1200px\" title=\""+data.title+"\" frameborder=\"0\" marginwidth=\"0\" marginheight=\"0\" scrolling=\"no\" allowfullscreen\u003e\u003c/iframe\u003e\n"
     }
   );
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -7,8 +7,7 @@ const { body,validationResult } = require('express-validator');
 
 router.get("/", function (req, res) {
     res.render("index", {
-        title: "Docker NodeJS Template!",
-        body: "Hello, World!",
+        title: "Welcome to MPS Embed!",
     });
 })
 

--- a/views/index.eta
+++ b/views/index.eta
@@ -3,7 +3,7 @@
 <div id="main-container" class="container">
   <div class="row">
       <div class="col-md-12">
-        <h2>Welcome to MPS Embed!</h2>
+        <h2><%= it.title %></h2>
       </div>
   </div>
   <div class="row">


### PR DESCRIPTION
**Embed reads the IIIF Manifest of the object to determine if it should remove the Pager.*
* * *

**JIRA Ticket**: [LTSVIEWER-117](https://jira.huit.harvard.edu/browse/LTSVIEWER-117)

# What does this Pull Request do?
Embed now reads the IIIF Manifest of the item and looks for the 'viewerHint' property. If the `viewerHint` is set to `individuals` this means it is a single page item, so it adds a request parameter `?removePager=1` to the viewerUrl in the oEmbed response (including in the <iframe> tag contained in the `html` element of the oEmbed response.

# How should this be tested?

A description of what steps someone could take to:
* Completely rebuild the container using the `delivery-type` branch.
* Click on any of the items on the homepage.
* If the item is a single image, then in the `viewer_url` in the oEmbed response should end with `?removePager=1`. For example:  "https://localhost:23017/viewer/ids/10274486?removePager=1"
* If the item contains multiple images, then the `viewer_url` in the oEmbed response should _NOT_ end with `?removePager=1`. For example: "https://localhost:23017/viewer/drs/4997399?"

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz 