### PR TITLE
Title fixed for both v2 and v3 mps manifests.

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -88,8 +88,15 @@ router.get('/mps', async function(req, res, next) {
   viewerUrl.searchParams.append("manifestId", manifestId);
   consoleLogger.debug(viewerUrl);
 
-  const title = manifestData.id || '';
-  //const title = manifestData.metadata[0].value[0] || '';
+  let title = manifestData.id || ''; 
+  if (manifestData.hasOwnProperty('label')) {
+    if (manifestData.label.hasOwnProperty('none')) {
+      title = manifestData.label.none[0] || '';
+    } 
+    else {
+      title = manifestData.label || '';
+    }
+  }
   
   res.json( 
     {

--- a/routes/api.js
+++ b/routes/api.js
@@ -89,6 +89,8 @@ router.get('/mps', async function(req, res, next) {
   consoleLogger.debug(viewerUrl);
 
   const title = manifestData.id || '';
+  //const title = manifestData.metadata[0].value[0] || '';
+  
 
   res.json( 
     {

--- a/routes/api.js
+++ b/routes/api.js
@@ -91,7 +91,6 @@ router.get('/mps', async function(req, res, next) {
   const title = manifestData.id || '';
   //const title = manifestData.metadata[0].value[0] || '';
   
-
   res.json( 
     {
       type: "mps",


### PR DESCRIPTION
**Title fixed for both v2 and v3 mps manifests.**
* * *

**JIRA Ticket**: [LTSVIEWER-202](https://jira.huit.harvard.edu/browse/LTSVIEWER-202)

# What does this Pull Request do?
This fixes the title for mps manifests. Both v2 and v3 mps manifests are displaying.

# How should this be tested?

A description of what steps someone could take to:
* Rebuild `mps-embed` using the `LTSVIEWER-202` branch
* Bring up `mps-viewer` on the `main` branch.
* Clicking on any mps manifest should display the title / label of the item above the viewer.
* You could test it using dev, qa, or production examples by changing your `example-items.json` file and the `MPS_MANIFEST_BASEURL` variable in mps-embed `.env` 

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@f8f8ff @enriquediaz 