### PR TITLE
Adding use of example-items.json file.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,5 @@ docker-compose*
 /logs/*
 !/logs/.keep
 .config/
+config/*
+!config/example-items-example.txt

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,7 @@ dist
 .DS_Store
 
 .config/
+
+# Configuration
+/config/*
+!/config/example-items-example.txt

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ Docker Compose
 
 *Note: The config file .env is specifically excluded in .gitignore and .dockerignore, since it contains credentials it should NOT ever be committed to any repository.*
 
+### 3: Create example items
+
+#### Create config file for environment variables
+- Make a copy of the example items example file `./config/example-items-example.txt`
+- Rename the file to `example-items.json`
+- Replace placeholder values as necessary
+
+*Note: The config file .example-items.json is specifically excluded in .gitignore and .dockerignore, since the examples will differ from environment to environment.*
+
 ### 4: Start
 
 ##### START

--- a/config/example-items-example.txt
+++ b/config/example-items-example.txt
@@ -1,0 +1,22 @@
+{
+	"idsExamples": [{
+			"href": "/api/legacy?recordIdentifier=W401849_URN-3:HUL.ARCH:2009749",
+			"text": "Harvard University Baseball Team, photograph, 1892"
+		},
+		{
+			"href": "/api/legacy?recordIdentifier=W401827_URN-3:HUL.ARCH:2009747",
+			"text": "Harvard-Yale Baseball Game. Holmes Field, photograph, 1885"
+		},
+	],
+	"mpsExamples": [{
+			"href": "/api/mps?urn=URN-3:DIV.LIB.USC:3200357?manifestVersion=2",
+			"text": "Harvard Divinity School Unitarian Service Committee",
+			"version": 2
+		},
+		{
+			"href": "/api/mps?urn=URN-3:DIV.LIB.USC:3200357?manifestVersion=3",
+			"text": "Harvard Divinity School Unitarian Service Committee",
+			"version": 3
+		},
+	]
+}

--- a/controllers/examples.ctrl.js
+++ b/controllers/examples.ctrl.js
@@ -1,0 +1,15 @@
+const consoleLogger = require('../logger/logger.js').console;
+const fsPromises = require('fs').promises;
+const path = require('path');
+
+const examplesCtrl = {};
+
+examplesCtrl.getExamples = async () => {
+    
+    const data = await fsPromises.readFile(path.join(__dirname, '..', 'config', 'example-items.json'))
+        .catch((err) => console.error('Failed to read file', err));
+
+    return JSON.parse(data.toString());
+};
+
+module.exports = examplesCtrl;

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -14,6 +14,7 @@ services:
     volumes:
       - './:/home/mpsadm'
       - '/home/mpsadm/node_modules'
+      - './config/example-items.json:/home/mpsadm/config/example-items.json:ro'
     ports:
       - "23018:8081"
     # Join this service to a custom docker network

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,71 +1,19 @@
 const express = require('express');
 const router = express.Router();
+const examplesCtrl = require('../controllers/examples.ctrl');
+const consoleLogger = require('../logger/logger.js').console;
 
-router.get("/", function (req, res) {
+router.get("/", async (req, res) => {
 
-  const idsExamples = [
-    {
-      "href": "/api/legacy?recordIdentifier=W401849_URN-3:HUL.ARCH:2009749",
-      "text": "Harvard University Baseball Team, photograph, 1892"
-    },
-    {
-      "href": "/api/legacy?recordIdentifier=W401827_URN-3:HUL.ARCH:2009747",
-      "text": "Harvard-Yale Baseball Game. Holmes Field, photograph, 1885"
-    },
-    {
-      "href": "/api/legacy?recordIdentifier=W587091_URN-3:RAD.SCHL:11680642",
-      "text": "To roast a chicken; show #217"
-    },
-    {
-      "href": "/api/legacy?recordIdentifier=HUAM140429_URN-3:HUAM:INV012574P_DYNMC",
-      "text": "Untitled Drumset"
-    },
-    {
-      "href": "/api/legacy?recordIdentifier=990100671200203941",
-      "text": "Hot Dog In The Manger"
-    },
-    {
-      "href": "/api/legacy?recordIdentifier=990095204340203941",
-      "text": "Chronique du monde depuis la création, et des rois de France et d'Angleterre, jusqu'à l'an 1461: manuscript, [ca. 1461]. MS Typ 41. Houghton Library, Harvard University, Cambridge, Mass."
-    },
-    {
-      "href": "/api/legacy?recordIdentifier=990098789400203941",
-      "text": "Heures de Nôtre Dame (use of Troyes and Sens) : manuscript, [ca. 1470]"
+    let exampleItems;
+    try {
+      exampleItems = await examplesCtrl.getExamples();
+    } catch(e) {
+      consoleLogger.error(e);
     }
-  ];
 
-  const mpsExamples = [
-    {
-      "href": "/api/mps?urn=URN-3:DIV.LIB.USC:3200357&manifestVersion=2",
-      "text": "Harvard Divinity School Unitarian Service Committee",
-      "version": 2
-    },
-    {
-      "href": "/api/mps?urn=URN-3:DIV.LIB.USC:3200357&manifestVersion=3",
-      "text": "Harvard Divinity School Unitarian Service Committee",
-      "version": 3
-    },
-    {
-      "href": "/api/mps?urn=URN-3:FHCL:42632611&manifestVersion=2",
-      "text": "Harvard Yenching Fushun Xian zhi 37 juan",
-      "version": 2
-    },
-    {
-      "href": "/api/mps?urn=URN-3:FHCL:42632611&manifestVersion=3",
-      "text": "Harvard Yenching Fushun Xian zhi 37 juan",
-      "version": 3
-    },
-    {
-      "href": "/api/mps?urn=URN-3:FHCL:100001249&manifestVersion=2",
-      "text": "Tibetan Buddhist Resource Center",
-      "version": 2
-    },
-    {
-      "href": "/api/mps?urn=URN-3:FHCL:100001249&manifestVersion=3",
-      "text": "Tibetan Buddhist Resource Center",
-      "version": 3
-    }
-  ];
+    const idsExamples = exampleItems.idsExamples;
+    const mpsExamples = exampleItems.mpsExamples;
 
     res.render("index", {
       title: "Welcome to MPS Embed!",


### PR DESCRIPTION
**Adding use of example-items.json file.**
* * *

**JIRA Ticket**: [LTSVIEWER-217](https://jira.huit.harvard.edu/browse/LTSVIEWER-217)

# What does this Pull Request do?
This sets up mps-embed to use an example file (/config/example-items.json) to display the examples on the index page. This way we can have different examples for each environment (dev/qa/prod).

[Example-Items.zip](https://github.com/harvard-lts/mps-embed/files/12071775/Example-Items.zip)

# How should this be tested?

A description of what steps someone could take to:
* Pull in the latest code from `LTSVIEWER-217` branch
* Download the example files from the .zip file included in this PR.  Note that the format of the example urls are different than the examples in `mps-viewer`, so you cannot use the same `example-items.json` file that you use in `mps-viewer`.
* Copy the contents of one of the example files into a new file called `/config/example-items.json`
* Update the `MPS_MANIFEST_BASEURL` in your `.env` to match the environment of the examples you are using.
* Bring up the `mps-embed` container and the `mps-viewer` container
* Confirm that the examples that are in your example-items.json file correctly show up on the index page of `mps-embed`
* Confirm that if you click into each item, the embed json code displays properly
* Confirm that if you click on the `viewerUrl` of the embed json code that the item correctly loads in your viewer.
* Repeat this process for each environment's examples (dev/qa/prod).

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@f8f8ff @enriquediaz 