### PR TITLE
Adding in ability to modify width and height of the iframe.

### DIFF
--- a/controllers/dimensions.ctrl.js
+++ b/controllers/dimensions.ctrl.js
@@ -6,8 +6,7 @@ dimensionsCtrl.getDimension = (dimensionParameter, defaultValue) => {
     let currentDimension = defaultValue;
     if (dimensionParameter) {
         if (Number.isInteger(parseInt(dimensionParameter))) {
-            currentDimension = parseInt(dimensionParameter);
-            currentDimension = Math.abs(currentDimension);
+            currentDimension = Math.abs(parseInt(dimensionParameter));
         }
     }
     return currentDimension;

--- a/controllers/dimensions.ctrl.js
+++ b/controllers/dimensions.ctrl.js
@@ -6,7 +6,7 @@ dimensionsCtrl.getDimension = (dimensionParameter, defaultValue) => {
     let currentDimension = defaultValue;
     if (dimensionParameter) {
         if (Number.isInteger(parseInt(dimensionParameter))) {
-            currentDimension = parseInt(dimensionParameter);
+            currentDimension = parseInt(Math.abs(dimensionParameter));
         }
     }
     return currentDimension;

--- a/controllers/dimensions.ctrl.js
+++ b/controllers/dimensions.ctrl.js
@@ -6,7 +6,8 @@ dimensionsCtrl.getDimension = (dimensionParameter, defaultValue) => {
     let currentDimension = defaultValue;
     if (dimensionParameter) {
         if (Number.isInteger(parseInt(dimensionParameter))) {
-            currentDimension = parseInt(Math.abs(dimensionParameter));
+            currentDimension = parseInt(dimensionParameter);
+            currentDimension = Math.abs(currentDimension);
         }
     }
     return currentDimension;

--- a/controllers/dimensions.ctrl.js
+++ b/controllers/dimensions.ctrl.js
@@ -1,0 +1,15 @@
+const consoleLogger = require('../logger/logger.js').console;
+
+const dimensionsCtrl = {};
+
+dimensionsCtrl.getDimension = (dimensionParameter, defaultValue) => {
+    let currentDimension = defaultValue;
+    if (dimensionParameter) {
+        if (Number.isInteger(parseInt(dimensionParameter))) {
+            currentDimension = parseInt(dimensionParameter);
+        }
+    }
+    return currentDimension;
+}
+
+module.exports = dimensionsCtrl;

--- a/routes/api.js
+++ b/routes/api.js
@@ -4,6 +4,7 @@ const consoleLogger = require('../logger/logger.js').console;
 
 const legacyManifestsCtrl = require('../controllers/legacymanifests.ctrl');
 const mpsManifestsCtrl = require('../controllers/mpsmanifests.ctrl');
+const dimensionsCtrl = require('../controllers/dimensions.ctrl');
 
 const viewerServer = process.env.VIEWER_SERVER;
 
@@ -11,6 +12,8 @@ const viewerServer = process.env.VIEWER_SERVER;
 router.get('/legacy', async function(req, res, next) {
   
   let recordIdentifier = req.query.recordIdentifier;
+  let currentWidth=1200;
+  let currentHeight=700;
   const viewerUrl = new URL(`https://${viewerServer}/viewer/`);
 
   let data, result = {};
@@ -38,6 +41,11 @@ router.get('/legacy', async function(req, res, next) {
   consoleLogger.debug(`viewerUrl`);
   consoleLogger.debug(viewerUrl);
 
+  consoleLogger.debug('width: '+req.query.width);
+  consoleLogger.debug('height: '+req.query.height);
+  currentWidth = dimensionsCtrl.getDimension(req.query.width, currentWidth);
+  currentHeight = dimensionsCtrl.getDimension(req.query.height, currentHeight);
+
   res.json( 
     {
       type: data.uriType,
@@ -46,9 +54,9 @@ router.get('/legacy', async function(req, res, next) {
       title: data.title,
       iiif_manifest: manifestId,
       viewerUrl: viewerUrl,
-      height: 400,
-      width: null,
-      html: "\u003ciframe src=\""+viewerUrl+"\" height=\"700px\" width=\"1200px\" title=\""+data.title+"\" frameborder=\"0\" marginwidth=\"0\" marginheight=\"0\" scrolling=\"no\" allowfullscreen\u003e\u003c/iframe\u003e\n"
+      height: currentHeight,
+      width: currentWidth,
+      html: "\u003ciframe src='"+viewerUrl+"' height='"+currentHeight+"px' width='"+currentWidth+"px' title='"+data.title+"' frameborder='0' marginwidth='0' marginheight='0' scrolling='no' allowfullscreen\u003e\u003c/iframe\u003e"
     }
   );
 
@@ -66,6 +74,8 @@ router.get('/mps', async function(req, res, next) {
   consoleLogger.debug(`urn ${urn} manifestVersion ${manifestVersion}`);
 
   let manifestId, manifestResponse, manifestData;
+  let currentWidth=1200;
+  let currentHeight=700;
 
   try {
     manifestId = await mpsManifestsCtrl.getManifestId(urn, manifestVersion);
@@ -97,7 +107,12 @@ router.get('/mps', async function(req, res, next) {
       title = manifestData.label || '';
     }
   }
-  
+
+  consoleLogger.debug('width: '+req.query.width);
+  consoleLogger.debug('height: '+req.query.height);
+  currentWidth = dimensionsCtrl.getDimension(req.query.width, currentWidth);
+  currentHeight = dimensionsCtrl.getDimension(req.query.height, currentHeight); 
+
   res.json( 
     {
       type: "mps",
@@ -106,9 +121,9 @@ router.get('/mps', async function(req, res, next) {
       title: title,
       iiif_manifest: manifestId,
       viewerUrl: viewerUrl,
-      height: 400,
-      width: null,
-      html: "\u003ciframe src=\""+viewerUrl+"\" height=\"700px\" width=\"1200px\" title=\""+title+"\" frameborder=\"0\" marginwidth=\"0\" marginheight=\"0\" scrolling=\"no\" allowfullscreen\u003e\u003c/iframe\u003e\n"
+      height: currentHeight,
+      width: currentWidth,
+      html: "\u003ciframe src='"+viewerUrl+"' height='"+currentHeight+"px' width='"+currentWidth+"px' title='"+title+"' frameborder='0' marginwidth='0' marginheight='0' scrolling='no' allowfullscreen\u003e\u003c/iframe\u003e"
     }
   );
 


### PR DESCRIPTION
**Adding in ability to modify width and height of the iframe.**
* * *

**JIRA Ticket**: [LTSVIEWER-247](https://jira.huit.harvard.edu/browse/LTSVIEWER-247)

# What does this Pull Request do?
This adds in the ability to adjust the height and width of the iframe code returned in the json response by passing in integers to the `height` and `width` url parameters. If you do not pass in a valid integer or do not include the parameters at all it defaults to what was previously used (width: 1200px, height: 700px).

# How should this be tested?

A description of what steps someone could take to:
* Rebuild the embed container using the `LTSVIEWER-247` branch
* Go to any example item (both legacy and MPS items should work).
* Add width and height parameters to the url (example: https://localhost:23018/api/legacy?recordIdentifier=HUAM140429_URN-3:HUAM:INV012574P_DYNMC&width=560&height=420)
* Confirm that the height and width elements in the JSON response match what you put into the parameters
* Confirm that the height and width parameters in the `<iframe>` tag in  the `html` element of the JSON response match what you put into the parameters
* If you put in a non-integer it will fall back to the defaults (width:1200, height: 700)
* If you put in an integer that has non-integer characters after it, it will prune off the offending characters and just use the integer at the beginning (for example if you set width:`500abc` it will set the width to `500`)
* You could also take the resulting `<iframe>` tag and put it in an html page and confirm that it shows up (your mileage may vary for this when using localhost).

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@f8f8ff @enriquediaz 