### PR TITLE
Allowing dimensions to be either pixels or percent.

### DIFF
--- a/controllers/dimensions.ctrl.js
+++ b/controllers/dimensions.ctrl.js
@@ -3,10 +3,16 @@ const consoleLogger = require('../logger/logger.js').console;
 const dimensionsCtrl = {};
 
 dimensionsCtrl.getDimension = (dimensionParameter, defaultValue) => {
-    let currentDimension = defaultValue;
+    let currentDimension = defaultValue+'px';
     if (dimensionParameter) {
         if (Number.isInteger(parseInt(dimensionParameter))) {
             currentDimension = Math.abs(parseInt(dimensionParameter));
+            if (dimensionParameter.endsWith('%')) {
+                currentDimension = currentDimension+'%';
+            }
+            else {
+                currentDimension = currentDimension+'px'; 
+            }
         }
     }
     return currentDimension;

--- a/routes/api.js
+++ b/routes/api.js
@@ -45,7 +45,7 @@ router.get('/legacy', async function(req, res, next) {
   consoleLogger.debug('height: '+req.query.height);
   currentWidth = dimensionsCtrl.getDimension(req.query.width, currentWidth);
   currentHeight = dimensionsCtrl.getDimension(req.query.height, currentHeight);
-
+  
   res.json( 
     {
       type: data.uriType,
@@ -112,7 +112,7 @@ router.get('/mps', async function(req, res, next) {
   consoleLogger.debug('height: '+req.query.height);
   currentWidth = dimensionsCtrl.getDimension(req.query.width, currentWidth);
   currentHeight = dimensionsCtrl.getDimension(req.query.height, currentHeight); 
-
+  
   res.json( 
     {
       type: "mps",
@@ -123,7 +123,7 @@ router.get('/mps', async function(req, res, next) {
       viewerUrl: viewerUrl,
       height: currentHeight,
       width: currentWidth,
-      html: "\u003ciframe src='"+viewerUrl+"' height='"+currentHeight+"px' width='"+currentWidth+"px' title='"+title+"' frameborder='0' marginwidth='0' marginheight='0' scrolling='no' allowfullscreen\u003e\u003c/iframe\u003e"
+      html: "\u003ciframe src='"+viewerUrl+"' height='"+currentHeight+"' width='"+currentWidth+"' title='"+title+"' frameborder='0' marginwidth='0' marginheight='0' scrolling='no' allowfullscreen\u003e\u003c/iframe\u003e"
     }
   );
 


### PR DESCRIPTION
**Allowing dimensions to be either pixels or percent.**
* * *

**JIRA Ticket**: [LTSVIEWER-263](https://jira.huit.harvard.edu/browse/LTSVIEWER-263)

# What does this Pull Request do?
Because the new beta pages in LTSVIEWER-263 are displaying the viewer at 100% width, we needed to allow MPS Embed to pass in pixels or percentages in the `height` and `width` parameters.
# How should this be tested?

A description of what steps someone could take to:
* Rebuild the container using the `LTSVIEWER-263` branch
* Go to any item on the homepage.
* Add in height and/or width parameters to the url. If you add in numbers it should display them with `px` at the end. If you pass in numbers with a percent sign, it should add `%` to the end without adding a `px`.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@f8f8ff @enriquediaz 