### PR TITLE
Adding new /manifest/ route to embed for use with CURIOSity.

### DIFF
--- a/.bash_history
+++ b/.bash_history
@@ -1,0 +1,7 @@
+./healthcheck https://mps-embed:8081/healthcheck
+./healthcheck https://mps-embed:8081/healthcheck-random-string
+exit
+npm install eta@2 --save-dev
+exit
+exit
+exit

--- a/routes/api.js
+++ b/routes/api.js
@@ -129,4 +129,62 @@ router.get('/mps', async function(req, res, next) {
 
 });
 
+router.get('/manifest', async function(req, res, next) {
+
+  let result = {};
+  
+  const manifestId = req.query.manifestId;
+  const viewerUrl = new URL(`https://${viewerServer}/viewer/`);
+  
+  consoleLogger.debug("api.js /manifest");
+  consoleLogger.debug(`manifestId ${manifestId}`);
+
+  let manifestResponse, manifestData;
+  let currentWidth=1200;
+  let currentHeight=700;
+
+  try {
+    manifestResponse = await mpsManifestsCtrl.getManifest(manifestId);
+    manifestData = manifestResponse.data || {};
+  } catch(e) {
+    consoleLogger.error(e);
+    result.error = e;
+    return res.status(500).json(result);
+  }
+
+  //consoleLogger.debug(JSON.stringify(manifestData));
+  viewerUrl.searchParams.append("manifestId", manifestId);
+  consoleLogger.debug(viewerUrl);
+
+  let title = manifestData.id || ''; 
+  if (manifestData.hasOwnProperty('label')) {
+    if (manifestData.label.hasOwnProperty('none')) {
+      title = manifestData.label.none[0] || '';
+    } 
+    else {
+      title = manifestData.label || '';
+    }
+  }
+
+  consoleLogger.debug('width: '+req.query.width);
+  consoleLogger.debug('height: '+req.query.height);
+  currentWidth = dimensionsCtrl.getDimension(req.query.width, currentWidth);
+  currentHeight = dimensionsCtrl.getDimension(req.query.height, currentHeight); 
+  
+  res.json( 
+    {
+      type: "manifest",
+      version: "1.0",
+      provider_name: "MPS Embed",
+      title: title,
+      iiif_manifest: manifestId,
+      viewerUrl: viewerUrl,
+      height: currentHeight,
+      width: currentWidth,
+      html: "\u003ciframe src='"+viewerUrl+"' height='"+currentHeight+"' width='"+currentWidth+"' title='"+title+"' frameborder='0' marginwidth='0' marginheight='0' scrolling='no' allowfullscreen\u003e\u003c/iframe\u003e"
+    }
+  );
+
+});
+
 module.exports = router;


### PR DESCRIPTION
**Adding new /manifest/ route to embed for use with CURIOSity.**
* * *

**JIRA Ticket**: [LTSVIEWER-263](https://jira.huit.harvard.edu/browse/LTSVIEWER-263)

# What does this Pull Request do?
This adds a new route to mps-embed at `/manifest/` that allows you to pass in any Manifest URL.

# How should this be tested?

A description of what steps someone could take to:
* Rebuild the mps-embed container using the `LTSVIEWER-263` branch
* Go to this url: https://localhost:23018/example/manifest/?manifestId=[manifestId]&manifestVersion=3 where [manifestId] can be the URL of any Manifest. For example: https://localhost:23017/example/manifest/?manifestId=https://iiif.lib.harvard.edu/manifests/drs:8282494&manifestVersion=3
* You should see the the JSON response with the Manifest information inside it. The HTML iframe tag should have the viewer url in it with the manifest URL. 

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@f8f8ff @enriquediaz 