### PR TITLE
Bumping version to 0.2.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mps-embed",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mps-embed",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "axios": "^0.24.0",
         "body-parser": "^1.20.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mps-embed",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Testing out simple oembed for use with viewer.",
   "author": "Phil Plencner <philip_plencner@harvard.edu>",
   "main": "app.js",


### PR DESCRIPTION
**Bumping version to 0.2.0.**
* * *

This just bumps mps-embed to version 0.2.0 so we can tag a new production release.