### PR TITLE
Adding new production PTO examples.

### DIFF
--- a/config/example-items-dev.json
+++ b/config/example-items-dev.json
@@ -93,30 +93,39 @@
 			"environment": "DEV"
 		},
 		{
-			"version2": "/api/mps?urn=urn-3:DIV.LIB:42551491?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=urn-3:DIV.LIB:42551491?manifestVersion=3&prod=1",
-			"title": "Unitarian Service Committee. Case Files, 1938-1951.",
+			"version2": "/api/mps?urn=URN-3:DIV.LIB:29999858?manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=URN-3:DIV.LIB:29999858?manifestVersion=3&prod=1",
+			"title": "Foote, Henry Wilder, 1875-1964. Papers of Professor Henry Wilder Foote and Family, 1714-1959.",
 			"owner": "Harvard Divinity School",
 			"type": "page-turned object",
-			"size": "4 pages",
+			"size": "3 pages",
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=URN-3:FHCL:42632611?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=URN-3:FHCL:42632611?manifestVersion=3&prod=1",
-			"title": "Fushun Xian zhi 37 juan. cc China] Tongzhi 11 [1872] 1872.",
-			"owner": "Harvard Yenching Library",
+			"version2": "/api/mps?urn=URN-3:HLS.LIBR:102621314?manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=URN-3:HLS.LIBR:102621314?manifestVersion=3&prod=1",
+			"title": "Cecil F. Poole Papers, 1939-1997. Speeches.",
+			"owner": "Harvard Law School Library, Historical & Special Collections",
 			"type": "page-turned object",
-			"size": "116 pages",
+			"size": "transcripted, 121 pages",
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=URN-3:FHCL:100001249?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=URN-3:FHCL:100001249?manifestVersion=3&prod=1",
-			"title": "Tibetan Buddhist Resource Center.",
-			"owner": "Harvard Yenching Library",
+			"version2": "/api/mps?urn=URN-3:GSE.LIBR:42470991?manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=URN-3:GSE.LIBR:42470991?manifestVersion=3&prod=1",
+			"title": "Richards, I. A. (Ivor Armstrong) 1893-1979. Spansk gennem billeder. no 1975.",
+			"owner": "Gutman Library",
 			"type": "page-turned object",
-			"size": "650 pages",
+			"size": "spanish, transcripted, 468 pages",
+			"environment": "PROD"
+		},
+		{
+			"version2": "/api/mps?urn=URN-3:RAD.SCHL:101557499?manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=URN-3:RAD.SCHL:101557499?manifestVersion=3&prod=1",
+			"title": "National Organization for Women Newsletter Collection. New York. Nassau County chapter. Nassau NOW Times. Pr-1.",
+			"owner": "Radcliffe Institute",
+			"type": "page-turned object",
+			"size": "partially transcripted, 725 pages",
 			"environment": "PROD"
 		},
 		{

--- a/config/example-items-prod.json
+++ b/config/example-items-prod.json
@@ -57,30 +57,39 @@
 		}
 	],
 	"mpsExamples": [{
-			"version2": "/api/mps?urn=urn-3:DIV.LIB:42551491?manifestVersion=2",
-			"version3": "/api/mps?urn=urn-3:DIV.LIB:42551491?manifestVersion=3",
-			"title": "Unitarian Service Committee. Case Files, 1938-1951.",
+			"version2": "/api/mps?urn=URN-3:DIV.LIB:29999858?manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=URN-3:DIV.LIB:29999858?manifestVersion=3&prod=1",
+			"title": "Foote, Henry Wilder, 1875-1964. Papers of Professor Henry Wilder Foote and Family, 1714-1959.",
 			"owner": "Harvard Divinity School",
 			"type": "page-turned object",
-			"size": "4 pages",
+			"size": "3 pages",
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=URN-3:FHCL:42632611?manifestVersion=2",
-			"version3": "/api/mps?urn=URN-3:FHCL:42632611?manifestVersion=3",
-			"title": "Fushun Xian zhi 37 juan. cc China] Tongzhi 11 [1872] 1872.",
-			"owner": "Harvard Yenching Library",
+			"version2": "/api/mps?urn=URN-3:HLS.LIBR:102621314?manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=URN-3:HLS.LIBR:102621314?manifestVersion=3&prod=1",
+			"title": "Cecil F. Poole Papers, 1939-1997. Speeches.",
+			"owner": "Harvard Law School Library, Historical & Special Collections",
 			"type": "page-turned object",
-			"size": "116 pages",
+			"size": "transcripted, 121 pages",
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=URN-3:FHCL:100001249?manifestVersion=2",
-			"version3": "/api/mps?urn=URN-3:FHCL:100001249?manifestVersion=3",
-			"title": "Tibetan Buddhist Resource Center.",
-			"owner": "Harvard Yenching Library",
+			"version2": "/api/mps?urn=URN-3:GSE.LIBR:42470991?manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=URN-3:GSE.LIBR:42470991?manifestVersion=3&prod=1",
+			"title": "Richards, I. A. (Ivor Armstrong) 1893-1979. Spansk gennem billeder. no 1975.",
+			"owner": "Gutman Library",
 			"type": "page-turned object",
-			"size": "650 pages",
+			"size": "spanish, transcripted, 468 pages",
+			"environment": "PROD"
+		},
+		{
+			"version2": "/api/mps?urn=URN-3:RAD.SCHL:101557499?manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=URN-3:RAD.SCHL:101557499?manifestVersion=3&prod=1",
+			"title": "National Organization for Women Newsletter Collection. New York. Nassau County chapter. Nassau NOW Times. Pr-1.",
+			"owner": "Radcliffe Institute",
+			"type": "page-turned object",
+			"size": "partially transcripted, 725 pages",
 			"environment": "PROD"
 		},
 		{

--- a/config/example-items-qa.json
+++ b/config/example-items-qa.json
@@ -93,30 +93,39 @@
 			"environment": "QA"
 		},
 		{
-			"version2": "/api/mps?urn=urn-3:DIV.LIB:42551491?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=urn-3:DIV.LIB:42551491?manifestVersion=3&prod=1",
-			"title": "Unitarian Service Committee. Case Files, 1938-1951.",
+			"version2": "/api/mps?urn=URN-3:DIV.LIB:29999858?manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=URN-3:DIV.LIB:29999858?manifestVersion=3&prod=1",
+			"title": "Foote, Henry Wilder, 1875-1964. Papers of Professor Henry Wilder Foote and Family, 1714-1959.",
 			"owner": "Harvard Divinity School",
 			"type": "page-turned object",
-			"size": "4 pages",
+			"size": "3 pages",
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=URN-3:FHCL:42632611?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=URN-3:FHCL:42632611?manifestVersion=3&prod=1",
-			"title": "Fushun Xian zhi 37 juan. cc China] Tongzhi 11 [1872] 1872.",
-			"owner": "Harvard Yenching Library",
+			"version2": "/api/mps?urn=URN-3:HLS.LIBR:102621314?manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=URN-3:HLS.LIBR:102621314?manifestVersion=3&prod=1",
+			"title": "Cecil F. Poole Papers, 1939-1997. Speeches.",
+			"owner": "Harvard Law School Library, Historical & Special Collections",
 			"type": "page-turned object",
-			"size": "116 pages",
+			"size": "transcripted, 121 pages",
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=URN-3:FHCL:100001249?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=URN-3:FHCL:100001249?manifestVersion=3&prod=1",
-			"title": "Tibetan Buddhist Resource Center.",
-			"owner": "Harvard Yenching Library",
+			"version2": "/api/mps?urn=URN-3:GSE.LIBR:42470991?manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=URN-3:GSE.LIBR:42470991?manifestVersion=3&prod=1",
+			"title": "Richards, I. A. (Ivor Armstrong) 1893-1979. Spansk gennem billeder. no 1975.",
+			"owner": "Gutman Library",
 			"type": "page-turned object",
-			"size": "650 pages",
+			"size": "spanish, transcripted, 468 pages",
+			"environment": "PROD"
+		},
+		{
+			"version2": "/api/mps?urn=URN-3:RAD.SCHL:101557499?manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=URN-3:RAD.SCHL:101557499?manifestVersion=3&prod=1",
+			"title": "National Organization for Women Newsletter Collection. New York. Nassau County chapter. Nassau NOW Times. Pr-1.",
+			"owner": "Radcliffe Institute",
+			"type": "page-turned object",
+			"size": "partially transcripted, 725 pages",
 			"environment": "PROD"
 		},
 		{


### PR DESCRIPTION
**Adding new production PTO examples.**
* * *

**JIRA Ticket**: [LTSVIEWER-271](https://jira.huit.harvard.edu/browse/LTSVIEWER-271)

# What does this Pull Request do?
This updates the "Production" example items in each environment to use the following examples:

-     https://mps.lib.harvard.edu/iiif/3/URN-3:DIV.LIB:29999858 3-page PTO in production, post-fix, no transcription
-     https://mps.lib.harvard.edu/iiif/3/URN-3:HLS.LIBR:102621314 121-page PTO in production, post-fix, with transcriptions
-     https://mps.lib.harvard.edu/iiif/3/URN-3:GSE.LIBR:42470991 468-page PTO in production, post-fix, spanish, transcription
-     https://mps.lib.harvard.edu/iiif/3/URN-3:RAD.SCHL:101557499 725-page PTO in production, post-fix, partial transcripts

These examples have been re-ingested by MPS so they have both Version 2 and Version 3 IIIF Manifests.

# How should this be tested?

A description of what steps someone could take to:
* Pull in the latest code from the `new-prod-examples` branch for mps-embed
* Copy the code from `example-items-dev.json` and put it into `example-items.json.`
* In your .env file set `MPS_MANIFEST_BASEURL=https://mps-dev.lib.harvard.edu/iiif`
* Build the mps-embed application
* Ronfirm that the PTO examples (marked with the "Prod" icon) are the 4 listed above and they open in the Mirador 3 Viewer with both Version 2 and Version 3 Manifests.
* Repeat these steps using example-items-qa.json (MPS_MANIFEST_BASEURL=https://mps-qa.lib.harvard.edu/iiif) and example-items-prod.json (MPS_MANIFEST_BASEURL=https://mps.lib.harvard.edu/iiif). 

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@f8f8ff @enriquediaz 