### PR TITLE
Adding new nrs route and updating examples.

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,7 @@ const https = require('https');
 const http = require('http');
 const fs = require('fs');
 const eta = require('eta');
+const cors = require('cors');
 
 // App
 const app = express();
@@ -31,6 +32,11 @@ app.use('/', express.static(path.join(__dirname, 'public')));
 
 // Favicon
 app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
+
+// CORS
+app.use(cors({
+    origin: '*'
+}));
 
 // Bootstrap
 app.use('/css', express.static(__dirname + '/node_modules/bootstrap/dist/css'));

--- a/config/example-items-dev.json
+++ b/config/example-items-dev.json
@@ -57,8 +57,8 @@
 		}
 	],
 	"mpsExamples": [{
-			"version2": "/api/mps?urn=URN-3:HUL.OIS:101114808?manifestVersion=2",
-			"version3": "/api/mps?urn=URN-3:HUL.OIS:101114808?manifestVersion=3",
+			"version2": "/api/mps?urn=URN-3:HUL.OIS:101114808&manifestVersion=2",
+			"version3": "/api/mps?urn=URN-3:HUL.OIS:101114808&manifestVersion=3",
 			"nrs": "/api/nrs/?urn=URN-3:HUL.OIS:101114808",
 			"title": "Society for Basic Irreproducible Research, 010098243-METS.",
 			"owner": "Test item (no owner)",
@@ -67,8 +67,8 @@
 			"environment": "DEV"
 		},
 		{
-			"version2": "/api/mps?urn=URN-3:HUL.OIS:101114812?manifestVersion=2",
-			"version3": "/api/mps?urn=URN-3:HUL.OIS:101114812?manifestVersion=3",
+			"version2": "/api/mps?urn=URN-3:HUL.OIS:101114812&manifestVersion=2",
+			"version3": "/api/mps?urn=URN-3:HUL.OIS:101114812&manifestVersion=3",
 			"nrs": "/api/nrs/?urn=URN-3:HUL.OIS:101114812",
 			"title": "Society for Basic Irreproducible Research, 008971542_v001-METS.",
 			"owner": "Test item (no owner)",
@@ -77,8 +77,8 @@
 			"environment": "DEV"
 		},
 		{
-			"version2": "/api/mps?urn=URN-3:HUL.OIS:101114810?manifestVersion=2",
-			"version3": "/api/mps?urn=URN-3:HUL.OIS:101114810?manifestVersion=3",
+			"version2": "/api/mps?urn=URN-3:HUL.OIS:101114810&manifestVersion=2",
+			"version3": "/api/mps?urn=URN-3:HUL.OIS:101114810&manifestVersion=3",
 			"nrs": "/api/nrs/?urn=URN-3:HUL.OIS:101114810",
 			"title": "Society for Basic Irreproducible Research, 008106825_v001-METS.",
 			"owner": "Test item (no owner)",
@@ -87,8 +87,8 @@
 			"environment": "DEV"
 		},
 		{
-			"version2": "/api/mps?urn=URN-3:HUL.OIS:1254672?manifestVersion=2",
-			"version3": "/api/mps?urn=URN-3:HUL.OIS:1254672?manifestVersion=3",
+			"version2": "/api/mps?urn=URN-3:HUL.OIS:1254672&manifestVersion=2",
+			"version3": "/api/mps?urn=URN-3:HUL.OIS:1254672&manifestVersion=3",
 			"nrs": "/api/nrs/?urn=URN-3:HUL.OIS:1254672",
 			"title": "2000 node test pds object",
 			"owner": "Test item (no owner)",
@@ -97,8 +97,8 @@
 			"environment": "DEV"
 		},
 		{
-			"version2": "/api/mps?urn=URN-3:DIV.LIB:29999858?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=URN-3:DIV.LIB:29999858?manifestVersion=3&prod=1",
+			"version2": "/api/mps?urn=URN-3:DIV.LIB:29999858&manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=URN-3:DIV.LIB:29999858&manifestVersion=3&prod=1",
 			"nrs": "/api/nrs/?urn=URN-3:DIV.LIB:29999858&prod=1",
 			"title": "Foote, Henry Wilder, 1875-1964. Papers of Professor Henry Wilder Foote and Family, 1714-1959.",
 			"owner": "Harvard Divinity School",
@@ -107,8 +107,8 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=URN-3:HLS.LIBR:102621314?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=URN-3:HLS.LIBR:102621314?manifestVersion=3&prod=1",
+			"version2": "/api/mps?urn=URN-3:HLS.LIBR:102621314&manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=URN-3:HLS.LIBR:102621314&manifestVersion=3&prod=1",
 			"nrs": "/api/nrs/?urn=URN-3:HLS.LIBR:102621314&prod=1",
 			"title": "Cecil F. Poole Papers, 1939-1997. Speeches.",
 			"owner": "Harvard Law School Library, Historical & Special Collections",
@@ -117,8 +117,8 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=URN-3:GSE.LIBR:42470991?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=URN-3:GSE.LIBR:42470991?manifestVersion=3&prod=1",
+			"version2": "/api/mps?urn=URN-3:GSE.LIBR:42470991&manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=URN-3:GSE.LIBR:42470991&manifestVersion=3&prod=1",
 			"nrs": "/api/nrs/?urn=URN-3:GSE.LIBR:42470991&prod=1",
 			"title": "Richards, I. A. (Ivor Armstrong) 1893-1979. Spansk gennem billeder. no 1975.",
 			"owner": "Gutman Library",
@@ -127,8 +127,8 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=URN-3:RAD.SCHL:101557499?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=URN-3:RAD.SCHL:101557499?manifestVersion=3&prod=1",
+			"version2": "/api/mps?urn=URN-3:RAD.SCHL:101557499&manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=URN-3:RAD.SCHL:101557499&manifestVersion=3&prod=1",
 			"nrs": "/api/nrs/?urn=URN-3:RAD.SCHL:101557499&prod=1",
 			"title": "National Organization for Women Newsletter Collection. New York. Nassau County chapter. Nassau NOW Times. Pr-1.",
 			"owner": "Radcliffe Institute",
@@ -137,8 +137,8 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=urn-3:FHCL.JUD:40308070?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=urn-3:FHCL.JUD:40308070?manifestVersion=3&prod=1",
+			"version2": "/api/mps?urn=urn-3:FHCL.JUD:40308070&manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=urn-3:FHCL.JUD:40308070&manifestVersion=3&prod=1",
 			"nrs": "/api/nrs/?urn=urn-3:FHCL.JUD:40308070&prod=1",
 			"title": "Agor, Ya'akov, Israeli. Muze'on ha-ketav in Acre, Israel. 1960 - 1970.",
 			"owner": "Judaica Division, Widener Library",
@@ -147,8 +147,8 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=urn-3:KSG.LIBR:40505153?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=urn-3:KSG.LIBR:40505153?manifestVersion=3&prod=1",
+			"version2": "/api/mps?urn=urn-3:KSG.LIBR:40505153&manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=urn-3:KSG.LIBR:40505153&manifestVersion=3&prod=1",
 			"nrs": "/api/nrs/?urn=urn-3:KSG.LIBR:40505153&prod=1",
 			"title": "Krivokhizha, V. I. (VasiliÄ­ Iosifovich), 1947- Russia's national security policy, conceptions and realities.",
 			"owner": "Kennedy School Library",
@@ -157,8 +157,8 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=urn-3:FHCL.HOUGH:41301981?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=urn-3:FHCL.HOUGH:41301981?manifestVersion=3&prod=1",
+			"version2": "/api/mps?urn=urn-3:FHCL.HOUGH:41301981&manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=urn-3:FHCL.HOUGH:41301981&manifestVersion=3&prod=1",
 			"nrs": "/api/nrs/?urn=urn-3:FHCL.HOUGH:41301981&prod=1",
 			"title": "Thomas Prince journal, 1710-1751. MS Am 3039.",
 			"owner": "Houghton Library",
@@ -167,8 +167,8 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=urn-3:DOAK.RESLIB:40977022?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=urn-3:DOAK.RESLIB:40977022?manifestVersion=3&prod=1",
+			"version2": "/api/mps?urn=urn-3:DOAK.RESLIB:40977022&manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=urn-3:DOAK.RESLIB:40977022&manifestVersion=3&prod=1",
 			"nrs": "/api/nrs/?urn=urn-3:DOAK.RESLIB:40977022&prod=1",
 			"title": "Nativity. Church of Panagia tou Arakos, nave, west bay, south side, vault, wall paintings, Lagoudera, Cyprus, 1192.",
 			"owner": "Dumbarton Oaks Research Library",

--- a/config/example-items-dev.json
+++ b/config/example-items-dev.json
@@ -59,6 +59,7 @@
 	"mpsExamples": [{
 			"version2": "/api/mps?urn=URN-3:HUL.OIS:101114808?manifestVersion=2",
 			"version3": "/api/mps?urn=URN-3:HUL.OIS:101114808?manifestVersion=3",
+			"nrs": "/api/nrs/?urn=URN-3:HUL.OIS:101114808",
 			"title": "Society for Basic Irreproducible Research, 010098243-METS.",
 			"owner": "Test item (no owner)",
 			"type": "page-turned object",
@@ -68,6 +69,7 @@
 		{
 			"version2": "/api/mps?urn=URN-3:HUL.OIS:101114812?manifestVersion=2",
 			"version3": "/api/mps?urn=URN-3:HUL.OIS:101114812?manifestVersion=3",
+			"nrs": "/api/nrs/?urn=URN-3:HUL.OIS:101114812",
 			"title": "Society for Basic Irreproducible Research, 008971542_v001-METS.",
 			"owner": "Test item (no owner)",
 			"type": "page-turned object",
@@ -77,6 +79,7 @@
 		{
 			"version2": "/api/mps?urn=URN-3:HUL.OIS:101114810?manifestVersion=2",
 			"version3": "/api/mps?urn=URN-3:HUL.OIS:101114810?manifestVersion=3",
+			"nrs": "/api/nrs/?urn=URN-3:HUL.OIS:101114810",
 			"title": "Society for Basic Irreproducible Research, 008106825_v001-METS.",
 			"owner": "Test item (no owner)",
 			"type": "page-turned object",
@@ -86,6 +89,7 @@
 		{
 			"version2": "/api/mps?urn=URN-3:HUL.OIS:1254672?manifestVersion=2",
 			"version3": "/api/mps?urn=URN-3:HUL.OIS:1254672?manifestVersion=3",
+			"nrs": "/api/nrs/?urn=URN-3:HUL.OIS:1254672",
 			"title": "2000 node test pds object",
 			"owner": "Test item (no owner)",
 			"type": "page-turned object",
@@ -95,6 +99,7 @@
 		{
 			"version2": "/api/mps?urn=URN-3:DIV.LIB:29999858?manifestVersion=2&prod=1",
 			"version3": "/api/mps?urn=URN-3:DIV.LIB:29999858?manifestVersion=3&prod=1",
+			"nrs": "/api/nrs/?urn=URN-3:DIV.LIB:29999858&prod=1",
 			"title": "Foote, Henry Wilder, 1875-1964. Papers of Professor Henry Wilder Foote and Family, 1714-1959.",
 			"owner": "Harvard Divinity School",
 			"type": "page-turned object",
@@ -104,6 +109,7 @@
 		{
 			"version2": "/api/mps?urn=URN-3:HLS.LIBR:102621314?manifestVersion=2&prod=1",
 			"version3": "/api/mps?urn=URN-3:HLS.LIBR:102621314?manifestVersion=3&prod=1",
+			"nrs": "/api/nrs/?urn=URN-3:HLS.LIBR:102621314&prod=1",
 			"title": "Cecil F. Poole Papers, 1939-1997. Speeches.",
 			"owner": "Harvard Law School Library, Historical & Special Collections",
 			"type": "page-turned object",
@@ -113,6 +119,7 @@
 		{
 			"version2": "/api/mps?urn=URN-3:GSE.LIBR:42470991?manifestVersion=2&prod=1",
 			"version3": "/api/mps?urn=URN-3:GSE.LIBR:42470991?manifestVersion=3&prod=1",
+			"nrs": "/api/nrs/?urn=URN-3:GSE.LIBR:42470991&prod=1",
 			"title": "Richards, I. A. (Ivor Armstrong) 1893-1979. Spansk gennem billeder. no 1975.",
 			"owner": "Gutman Library",
 			"type": "page-turned object",
@@ -122,6 +129,7 @@
 		{
 			"version2": "/api/mps?urn=URN-3:RAD.SCHL:101557499?manifestVersion=2&prod=1",
 			"version3": "/api/mps?urn=URN-3:RAD.SCHL:101557499?manifestVersion=3&prod=1",
+			"nrs": "/api/nrs/?urn=URN-3:RAD.SCHL:101557499&prod=1",
 			"title": "National Organization for Women Newsletter Collection. New York. Nassau County chapter. Nassau NOW Times. Pr-1.",
 			"owner": "Radcliffe Institute",
 			"type": "page-turned object",
@@ -131,6 +139,7 @@
 		{
 			"version2": "/api/mps?urn=urn-3:FHCL.JUD:40308070?manifestVersion=2&prod=1",
 			"version3": "/api/mps?urn=urn-3:FHCL.JUD:40308070?manifestVersion=3&prod=1",
+			"nrs": "/api/nrs/?urn=urn-3:FHCL.JUD:40308070&prod=1",
 			"title": "Agor, Ya'akov, Israeli. Muze'on ha-ketav in Acre, Israel. 1960 - 1970.",
 			"owner": "Judaica Division, Widener Library",
 			"type": "single image",
@@ -140,6 +149,7 @@
 		{
 			"version2": "/api/mps?urn=urn-3:KSG.LIBR:40505153?manifestVersion=2&prod=1",
 			"version3": "/api/mps?urn=urn-3:KSG.LIBR:40505153?manifestVersion=3&prod=1",
+			"nrs": "/api/nrs/?urn=urn-3:KSG.LIBR:40505153&prod=1",
 			"title": "Krivokhizha, V. I. (VasiliÄ­ Iosifovich), 1947- Russia's national security policy, conceptions and realities.",
 			"owner": "Kennedy School Library",
 			"type": "single image",
@@ -149,6 +159,7 @@
 		{
 			"version2": "/api/mps?urn=urn-3:FHCL.HOUGH:41301981?manifestVersion=2&prod=1",
 			"version3": "/api/mps?urn=urn-3:FHCL.HOUGH:41301981?manifestVersion=3&prod=1",
+			"nrs": "/api/nrs/?urn=urn-3:FHCL.HOUGH:41301981&prod=1",
 			"title": "Thomas Prince journal, 1710-1751. MS Am 3039.",
 			"owner": "Houghton Library",
 			"type": "single image",
@@ -158,6 +169,7 @@
 		{
 			"version2": "/api/mps?urn=urn-3:DOAK.RESLIB:40977022?manifestVersion=2&prod=1",
 			"version3": "/api/mps?urn=urn-3:DOAK.RESLIB:40977022?manifestVersion=3&prod=1",
+			"nrs": "/api/nrs/?urn=urn-3:DOAK.RESLIB:40977022&prod=1",
 			"title": "Nativity. Church of Panagia tou Arakos, nave, west bay, south side, vault, wall paintings, Lagoudera, Cyprus, 1192.",
 			"owner": "Dumbarton Oaks Research Library",
 			"type": "single image",

--- a/config/example-items-example.txt
+++ b/config/example-items-example.txt
@@ -17,8 +17,8 @@
 		},
 	],
 	"mpsExamples": [{
-			"version2": "/api/mps?urn=URN-3:HUL.GUEST:409464?manifestVersion=2",
-			"version3": "/api/mps?urn=URN-3:HUL.GUEST:409464?manifestVersion=3",
+			"version2": "/api/mps?urn=URN-3:HUL.GUEST:409464&manifestVersion=2",
+			"version3": "/api/mps?urn=URN-3:HUL.GUEST:409464&manifestVersion=3",
 			"title": "Mosquito brigades and how to organize them.",
 			"owner": "Test item (no owner)",
 			"type": "page-turned object",
@@ -26,8 +26,8 @@
 			"environment": "QA"
 		},
 		{
-			"version2": "/api/mps?urn=urn-3:DIV.LIB:42551491?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=urn-3:DIV.LIB:42551491?manifestVersion=3&prod=1",
+			"version2": "/api/mps?urn=urn-3:DIV.LIB:42551491&manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=urn-3:DIV.LIB:42551491&manifestVersion=3&prod=1",
 			"title": "Unitarian Service Committee. Case Files, 1938-1951.",
 			"owner": "Harvard Divinity School",
 			"type": "page-turned object",

--- a/config/example-items-prod.json
+++ b/config/example-items-prod.json
@@ -57,8 +57,8 @@
 		}
 	],
 	"mpsExamples": [{
-			"version2": "/api/mps?urn=URN-3:DIV.LIB:29999858?manifestVersion=2",
-			"version3": "/api/mps?urn=URN-3:DIV.LIB:29999858?manifestVersion=3",
+			"version2": "/api/mps?urn=URN-3:DIV.LIB:29999858&manifestVersion=2",
+			"version3": "/api/mps?urn=URN-3:DIV.LIB:29999858&manifestVersion=3",
 			"nrs": "/api/nrs/?urn=URN-3:DIV.LIB:29999858",
 			"title": "Foote, Henry Wilder, 1875-1964. Papers of Professor Henry Wilder Foote and Family, 1714-1959.",
 			"owner": "Harvard Divinity School",
@@ -67,8 +67,8 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=URN-3:HLS.LIBR:102621314?manifestVersion=2",
-			"version3": "/api/mps?urn=URN-3:HLS.LIBR:102621314?manifestVersion=3",
+			"version2": "/api/mps?urn=URN-3:HLS.LIBR:102621314&manifestVersion=2",
+			"version3": "/api/mps?urn=URN-3:HLS.LIBR:102621314&manifestVersion=3",
 			"nrs": "/api/nrs/?urn=URN-3:HLS.LIBR:102621314",
 			"title": "Cecil F. Poole Papers, 1939-1997. Speeches.",
 			"owner": "Harvard Law School Library, Historical & Special Collections",
@@ -77,8 +77,8 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=URN-3:GSE.LIBR:42470991?manifestVersion=2",
-			"version3": "/api/mps?urn=URN-3:GSE.LIBR:42470991?manifestVersion=3",
+			"version2": "/api/mps?urn=URN-3:GSE.LIBR:42470991&manifestVersion=2",
+			"version3": "/api/mps?urn=URN-3:GSE.LIBR:42470991&manifestVersion=3",
 			"nrs": "/api/nrs/?urn=URN-3:GSE.LIBR:42470991",
 			"title": "Richards, I. A. (Ivor Armstrong) 1893-1979. Spansk gennem billeder. no 1975.",
 			"owner": "Gutman Library",
@@ -87,8 +87,8 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=URN-3:RAD.SCHL:101557499?manifestVersion=2",
-			"version3": "/api/mps?urn=URN-3:RAD.SCHL:101557499?manifestVersion=3",
+			"version2": "/api/mps?urn=URN-3:RAD.SCHL:101557499&manifestVersion=2",
+			"version3": "/api/mps?urn=URN-3:RAD.SCHL:101557499&manifestVersion=3",
 			"nrs": "/api/nrs/?urn=URN-3:RAD.SCHL:101557499",
 			"title": "National Organization for Women Newsletter Collection. New York. Nassau County chapter. Nassau NOW Times. Pr-1.",
 			"owner": "Radcliffe Institute",
@@ -97,8 +97,8 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=urn-3:FHCL.JUD:40308070?manifestVersion=2",
-			"version3": "/api/mps?urn=urn-3:FHCL.JUD:40308070?manifestVersion=3",
+			"version2": "/api/mps?urn=urn-3:FHCL.JUD:40308070&manifestVersion=2",
+			"version3": "/api/mps?urn=urn-3:FHCL.JUD:40308070&manifestVersion=3",
 			"nrs": "/api/nrs/?urn=urn-3:FHCL.JUD:40308070",
 			"title": "Agor, Ya'akov, Israeli. Muze'on ha-ketav in Acre, Israel. 1960 - 1970.",
 			"owner": "Judaica Division, Widener Library",
@@ -107,8 +107,8 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=urn-3:KSG.LIBR:40505153?manifestVersion=2",
-			"version3": "/api/mps?urn=urn-3:KSG.LIBR:40505153?manifestVersion=3",
+			"version2": "/api/mps?urn=urn-3:KSG.LIBR:40505153&manifestVersion=2",
+			"version3": "/api/mps?urn=urn-3:KSG.LIBR:40505153&manifestVersion=3",
 			"nrs": "/api/nrs/?urn=urn-3:KSG.LIBR:40505153",
 			"title": "Krivokhizha, V. I. (VasiliÄ­ Iosifovich), 1947- Russia's national security policy, conceptions and realities.",
 			"owner": "Kennedy School Library",
@@ -117,8 +117,8 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=urn-3:FHCL.HOUGH:41301981?manifestVersion=2",
-			"version3": "/api/mps?urn=urn-3:FHCL.HOUGH:41301981?manifestVersion=3",
+			"version2": "/api/mps?urn=urn-3:FHCL.HOUGH:41301981&manifestVersion=2",
+			"version3": "/api/mps?urn=urn-3:FHCL.HOUGH:41301981&manifestVersion=3",
 			"nrs": "/api/nrs/?urn=urn-3:FHCL.HOUGH:41301981",
 			"title": "Thomas Prince journal, 1710-1751. MS Am 3039.",
 			"owner": "Houghton Library",
@@ -127,8 +127,8 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=urn-3:DOAK.RESLIB:40977022?manifestVersion=2",
-			"version3": "/api/mps?urn=urn-3:DOAK.RESLIB:40977022?manifestVersion=3",
+			"version2": "/api/mps?urn=urn-3:DOAK.RESLIB:40977022&manifestVersion=2",
+			"version3": "/api/mps?urn=urn-3:DOAK.RESLIB:40977022&manifestVersion=3",
 			"nrs": "/api/nrs/?urn=urn-3:DOAK.RESLIB:40977022",
 			"title": "Nativity. Church of Panagia tou Arakos, nave, west bay, south side, vault, wall paintings, Lagoudera, Cyprus, 1192.",
 			"owner": "Dumbarton Oaks Research Library",

--- a/config/example-items-prod.json
+++ b/config/example-items-prod.json
@@ -57,8 +57,9 @@
 		}
 	],
 	"mpsExamples": [{
-			"version2": "/api/mps?urn=URN-3:DIV.LIB:29999858?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=URN-3:DIV.LIB:29999858?manifestVersion=3&prod=1",
+			"version2": "/api/mps?urn=URN-3:DIV.LIB:29999858?manifestVersion=2",
+			"version3": "/api/mps?urn=URN-3:DIV.LIB:29999858?manifestVersion=3",
+			"nrs": "/api/nrs/?urn=URN-3:DIV.LIB:29999858",
 			"title": "Foote, Henry Wilder, 1875-1964. Papers of Professor Henry Wilder Foote and Family, 1714-1959.",
 			"owner": "Harvard Divinity School",
 			"type": "page-turned object",
@@ -66,8 +67,9 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=URN-3:HLS.LIBR:102621314?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=URN-3:HLS.LIBR:102621314?manifestVersion=3&prod=1",
+			"version2": "/api/mps?urn=URN-3:HLS.LIBR:102621314?manifestVersion=2",
+			"version3": "/api/mps?urn=URN-3:HLS.LIBR:102621314?manifestVersion=3",
+			"nrs": "/api/nrs/?urn=URN-3:HLS.LIBR:102621314",
 			"title": "Cecil F. Poole Papers, 1939-1997. Speeches.",
 			"owner": "Harvard Law School Library, Historical & Special Collections",
 			"type": "page-turned object",
@@ -75,8 +77,9 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=URN-3:GSE.LIBR:42470991?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=URN-3:GSE.LIBR:42470991?manifestVersion=3&prod=1",
+			"version2": "/api/mps?urn=URN-3:GSE.LIBR:42470991?manifestVersion=2",
+			"version3": "/api/mps?urn=URN-3:GSE.LIBR:42470991?manifestVersion=3",
+			"nrs": "/api/nrs/?urn=URN-3:GSE.LIBR:42470991",
 			"title": "Richards, I. A. (Ivor Armstrong) 1893-1979. Spansk gennem billeder. no 1975.",
 			"owner": "Gutman Library",
 			"type": "page-turned object",
@@ -84,8 +87,9 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=URN-3:RAD.SCHL:101557499?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=URN-3:RAD.SCHL:101557499?manifestVersion=3&prod=1",
+			"version2": "/api/mps?urn=URN-3:RAD.SCHL:101557499?manifestVersion=2",
+			"version3": "/api/mps?urn=URN-3:RAD.SCHL:101557499?manifestVersion=3",
+			"nrs": "/api/nrs/?urn=URN-3:RAD.SCHL:101557499",
 			"title": "National Organization for Women Newsletter Collection. New York. Nassau County chapter. Nassau NOW Times. Pr-1.",
 			"owner": "Radcliffe Institute",
 			"type": "page-turned object",
@@ -95,6 +99,7 @@
 		{
 			"version2": "/api/mps?urn=urn-3:FHCL.JUD:40308070?manifestVersion=2",
 			"version3": "/api/mps?urn=urn-3:FHCL.JUD:40308070?manifestVersion=3",
+			"nrs": "/api/nrs/?urn=urn-3:FHCL.JUD:40308070",
 			"title": "Agor, Ya'akov, Israeli. Muze'on ha-ketav in Acre, Israel. 1960 - 1970.",
 			"owner": "Judaica Division, Widener Library",
 			"type": "single image",
@@ -104,6 +109,7 @@
 		{
 			"version2": "/api/mps?urn=urn-3:KSG.LIBR:40505153?manifestVersion=2",
 			"version3": "/api/mps?urn=urn-3:KSG.LIBR:40505153?manifestVersion=3",
+			"nrs": "/api/nrs/?urn=urn-3:KSG.LIBR:40505153",
 			"title": "Krivokhizha, V. I. (VasiliÄ­ Iosifovich), 1947- Russia's national security policy, conceptions and realities.",
 			"owner": "Kennedy School Library",
 			"type": "single image",
@@ -113,6 +119,7 @@
 		{
 			"version2": "/api/mps?urn=urn-3:FHCL.HOUGH:41301981?manifestVersion=2",
 			"version3": "/api/mps?urn=urn-3:FHCL.HOUGH:41301981?manifestVersion=3",
+			"nrs": "/api/nrs/?urn=urn-3:FHCL.HOUGH:41301981",
 			"title": "Thomas Prince journal, 1710-1751. MS Am 3039.",
 			"owner": "Houghton Library",
 			"type": "single image",
@@ -122,6 +129,7 @@
 		{
 			"version2": "/api/mps?urn=urn-3:DOAK.RESLIB:40977022?manifestVersion=2",
 			"version3": "/api/mps?urn=urn-3:DOAK.RESLIB:40977022?manifestVersion=3",
+			"nrs": "/api/nrs/?urn=urn-3:DOAK.RESLIB:40977022",
 			"title": "Nativity. Church of Panagia tou Arakos, nave, west bay, south side, vault, wall paintings, Lagoudera, Cyprus, 1192.",
 			"owner": "Dumbarton Oaks Research Library",
 			"type": "single image",

--- a/config/example-items-qa.json
+++ b/config/example-items-qa.json
@@ -57,8 +57,8 @@
 		}
 	],
 	"mpsExamples": [{
-			"version2": "/api/mps?urn=URN-3:HUL.GUEST:409464?manifestVersion=2",
-			"version3": "/api/mps?urn=URN-3:HUL.GUEST:409464?manifestVersion=3",
+			"version2": "/api/mps?urn=URN-3:HUL.GUEST:409464&manifestVersion=2",
+			"version3": "/api/mps?urn=URN-3:HUL.GUEST:409464&manifestVersion=3",
 			"nrs": "/api/nrs/?urn=URN-3:HUL.GUEST:409464",
 			"title": "Mosquito brigades and how to organize them.",
 			"owner": "Test item (no owner)",
@@ -67,8 +67,8 @@
 			"environment": "QA"
 		},
 		{
-			"version2": "/api/mps?urn=URN-3:HUL.OIS:100102314?manifestVersion=2",
-			"version3": "/api/mps?urn=URN-3:HUL.OIS:100102314?manifestVersion=3",
+			"version2": "/api/mps?urn=URN-3:HUL.OIS:100102314&manifestVersion=2",
+			"version3": "/api/mps?urn=URN-3:HUL.OIS:100102314&manifestVersion=3",
 			"nrs": "/api/nrs/?urn=URN-3:HUL.OIS:100102314",
 			"title": "Da Qing jin shen quan shu (Tongzhi jiu nian geng wu xia ji) cc Jingdu Rong lu tang Tongzhi 9 [1870].",
 			"owner": "Test item (no owner)",
@@ -77,8 +77,8 @@
 			"environment": "QA"
 		},
 		{
-			"version2": "/api/mps?urn=URN-3:GSE.LIBR:100041477?manifestVersion=2",
-			"version3": "/api/mps?urn=URN-3:GSE.LIBR:100041477?manifestVersion=3",
+			"version2": "/api/mps?urn=URN-3:GSE.LIBR:100041477&manifestVersion=2",
+			"version3": "/api/mps?urn=URN-3:GSE.LIBR:100041477&manifestVersion=3",
 			"nrs": "/api/nrs/?urn=URN-3:GSE.LIBR:100041477",
 			"title": "North Carolina teachers record. Raleigh, N.C. North Carolina Teachers Association. Volume 37. No. 3. May 1967. ",
 			"owner": "Wilson Library, University of North Carolina Chapel Hill, Black Teacher Archive",
@@ -87,8 +87,8 @@
 			"environment": "QA"
 		},
 		{
-			"version2": "/api/mps?urn=URN-3:GSE.LIBR:100037458?manifestVersion=2",
-			"version3": "/api/mps?urn=URN-3:GSE.LIBR:100037458?manifestVersion=3",
+			"version2": "/api/mps?urn=URN-3:GSE.LIBR:100037458&manifestVersion=2",
+			"version3": "/api/mps?urn=URN-3:GSE.LIBR:100037458&manifestVersion=3",
 			"nrs": "/api/nrs/?urn=URN-3:GSE.LIBR:100037458",
 			"title": "North Carolina teachers record. Raleigh, N.C. North Carolina Teachers Association. Volume 23. No. 2. Mar. 1952.",
 			"owner": "Wilson Library, University of North Carolina Chapel Hill, Black Teacher Archive",
@@ -97,8 +97,8 @@
 			"environment": "QA"
 		},
 		{
-			"version2": "/api/mps?urn=URN-3:DIV.LIB:29999858?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=URN-3:DIV.LIB:29999858?manifestVersion=3&prod=1",
+			"version2": "/api/mps?urn=URN-3:DIV.LIB:29999858&manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=URN-3:DIV.LIB:29999858&manifestVersion=3&prod=1",
 			"nrs": "/api/nrs/?urn=URN-3:DIV.LIB:29999858&prod=1",
 			"title": "Foote, Henry Wilder, 1875-1964. Papers of Professor Henry Wilder Foote and Family, 1714-1959.",
 			"owner": "Harvard Divinity School",
@@ -107,8 +107,8 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=URN-3:HLS.LIBR:102621314?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=URN-3:HLS.LIBR:102621314?manifestVersion=3&prod=1",
+			"version2": "/api/mps?urn=URN-3:HLS.LIBR:102621314&manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=URN-3:HLS.LIBR:102621314&manifestVersion=3&prod=1",
 			"nrs": "/api/nrs/?urn=URN-3:HLS.LIBR:102621314&prod=1",
 			"title": "Cecil F. Poole Papers, 1939-1997. Speeches.",
 			"owner": "Harvard Law School Library, Historical & Special Collections",
@@ -117,8 +117,8 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=URN-3:GSE.LIBR:42470991?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=URN-3:GSE.LIBR:42470991?manifestVersion=3&prod=1",
+			"version2": "/api/mps?urn=URN-3:GSE.LIBR:42470991&manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=URN-3:GSE.LIBR:42470991&manifestVersion=3&prod=1",
 			"nrs": "/api/nrs/?urn=URN-3:GSE.LIBR:42470991&prod=1",
 			"title": "Richards, I. A. (Ivor Armstrong) 1893-1979. Spansk gennem billeder. no 1975.",
 			"owner": "Gutman Library",
@@ -127,8 +127,8 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=URN-3:RAD.SCHL:101557499?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=URN-3:RAD.SCHL:101557499?manifestVersion=3&prod=1",
+			"version2": "/api/mps?urn=URN-3:RAD.SCHL:101557499&manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=URN-3:RAD.SCHL:101557499&manifestVersion=3&prod=1",
 			"nrs": "/api/nrs/?urn=URN-3:RAD.SCHL:101557499&prod=1",
 			"title": "National Organization for Women Newsletter Collection. New York. Nassau County chapter. Nassau NOW Times. Pr-1.",
 			"owner": "Radcliffe Institute",
@@ -137,8 +137,8 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=urn-3:FHCL.JUD:40308070?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=urn-3:FHCL.JUD:40308070?manifestVersion=3&prod=1",
+			"version2": "/api/mps?urn=urn-3:FHCL.JUD:40308070&manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=urn-3:FHCL.JUD:40308070&manifestVersion=3&prod=1",
 			"nrs": "/api/nrs/?urn=urn-3:FHCL.JUD:40308070&prod=1",
 			"title": "Agor, Ya'akov, Israeli. Muze'on ha-ketav in Acre, Israel. 1960 - 1970.",
 			"owner": "Judaica Division, Widener Library",
@@ -147,8 +147,8 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=urn-3:KSG.LIBR:40505153?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=urn-3:KSG.LIBR:40505153?manifestVersion=3&prod=1",
+			"version2": "/api/mps?urn=urn-3:KSG.LIBR:40505153&manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=urn-3:KSG.LIBR:40505153&manifestVersion=3&prod=1",
 			"nrs": "/api/nrs/?urn=urn-3:KSG.LIBR:40505153&prod=1",
 			"title": "Krivokhizha, V. I. (VasiliÄ­ Iosifovich), 1947- Russia's national security policy, conceptions and realities.",
 			"owner": "Kennedy School Library",
@@ -157,8 +157,8 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=urn-3:FHCL.HOUGH:41301981?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=urn-3:FHCL.HOUGH:41301981?manifestVersion=3&prod=1",
+			"version2": "/api/mps?urn=urn-3:FHCL.HOUGH:41301981&manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=urn-3:FHCL.HOUGH:41301981&manifestVersion=3&prod=1",
 			"nrs": "/api/nrs/?urn=urn-3:FHCL.HOUGH:41301981&prod=1",
 			"title": "Thomas Prince journal, 1710-1751. MS Am 3039.",
 			"owner": "Houghton Library",
@@ -167,8 +167,8 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/api/mps?urn=urn-3:DOAK.RESLIB:40977022?manifestVersion=2&prod=1",
-			"version3": "/api/mps?urn=urn-3:DOAK.RESLIB:40977022?manifestVersion=3&prod=1",
+			"version2": "/api/mps?urn=urn-3:DOAK.RESLIB:40977022&manifestVersion=2&prod=1",
+			"version3": "/api/mps?urn=urn-3:DOAK.RESLIB:40977022&manifestVersion=3&prod=1",
 			"nrs": "/api/nrs/?urn=urn-3:DOAK.RESLIB:40977022&prod=1",
 			"title": "Nativity. Church of Panagia tou Arakos, nave, west bay, south side, vault, wall paintings, Lagoudera, Cyprus, 1192.",
 			"owner": "Dumbarton Oaks Research Library",

--- a/config/example-items-qa.json
+++ b/config/example-items-qa.json
@@ -59,6 +59,7 @@
 	"mpsExamples": [{
 			"version2": "/api/mps?urn=URN-3:HUL.GUEST:409464?manifestVersion=2",
 			"version3": "/api/mps?urn=URN-3:HUL.GUEST:409464?manifestVersion=3",
+			"nrs": "/api/nrs/?urn=URN-3:HUL.GUEST:409464",
 			"title": "Mosquito brigades and how to organize them.",
 			"owner": "Test item (no owner)",
 			"type": "page-turned object",
@@ -68,6 +69,7 @@
 		{
 			"version2": "/api/mps?urn=URN-3:HUL.OIS:100102314?manifestVersion=2",
 			"version3": "/api/mps?urn=URN-3:HUL.OIS:100102314?manifestVersion=3",
+			"nrs": "/api/nrs/?urn=URN-3:HUL.OIS:100102314",
 			"title": "Da Qing jin shen quan shu (Tongzhi jiu nian geng wu xia ji) cc Jingdu Rong lu tang Tongzhi 9 [1870].",
 			"owner": "Test item (no owner)",
 			"type": "page-turned object",
@@ -77,6 +79,7 @@
 		{
 			"version2": "/api/mps?urn=URN-3:GSE.LIBR:100041477?manifestVersion=2",
 			"version3": "/api/mps?urn=URN-3:GSE.LIBR:100041477?manifestVersion=3",
+			"nrs": "/api/nrs/?urn=URN-3:GSE.LIBR:100041477",
 			"title": "North Carolina teachers record. Raleigh, N.C. North Carolina Teachers Association. Volume 37. No. 3. May 1967. ",
 			"owner": "Wilson Library, University of North Carolina Chapel Hill, Black Teacher Archive",
 			"type": "page-turned object",
@@ -86,6 +89,7 @@
 		{
 			"version2": "/api/mps?urn=URN-3:GSE.LIBR:100037458?manifestVersion=2",
 			"version3": "/api/mps?urn=URN-3:GSE.LIBR:100037458?manifestVersion=3",
+			"nrs": "/api/nrs/?urn=URN-3:GSE.LIBR:100037458",
 			"title": "North Carolina teachers record. Raleigh, N.C. North Carolina Teachers Association. Volume 23. No. 2. Mar. 1952.",
 			"owner": "Wilson Library, University of North Carolina Chapel Hill, Black Teacher Archive",
 			"type": "page-turned object",
@@ -95,6 +99,7 @@
 		{
 			"version2": "/api/mps?urn=URN-3:DIV.LIB:29999858?manifestVersion=2&prod=1",
 			"version3": "/api/mps?urn=URN-3:DIV.LIB:29999858?manifestVersion=3&prod=1",
+			"nrs": "/api/nrs/?urn=URN-3:DIV.LIB:29999858&prod=1",
 			"title": "Foote, Henry Wilder, 1875-1964. Papers of Professor Henry Wilder Foote and Family, 1714-1959.",
 			"owner": "Harvard Divinity School",
 			"type": "page-turned object",
@@ -104,6 +109,7 @@
 		{
 			"version2": "/api/mps?urn=URN-3:HLS.LIBR:102621314?manifestVersion=2&prod=1",
 			"version3": "/api/mps?urn=URN-3:HLS.LIBR:102621314?manifestVersion=3&prod=1",
+			"nrs": "/api/nrs/?urn=URN-3:HLS.LIBR:102621314&prod=1",
 			"title": "Cecil F. Poole Papers, 1939-1997. Speeches.",
 			"owner": "Harvard Law School Library, Historical & Special Collections",
 			"type": "page-turned object",
@@ -113,6 +119,7 @@
 		{
 			"version2": "/api/mps?urn=URN-3:GSE.LIBR:42470991?manifestVersion=2&prod=1",
 			"version3": "/api/mps?urn=URN-3:GSE.LIBR:42470991?manifestVersion=3&prod=1",
+			"nrs": "/api/nrs/?urn=URN-3:GSE.LIBR:42470991&prod=1",
 			"title": "Richards, I. A. (Ivor Armstrong) 1893-1979. Spansk gennem billeder. no 1975.",
 			"owner": "Gutman Library",
 			"type": "page-turned object",
@@ -122,6 +129,7 @@
 		{
 			"version2": "/api/mps?urn=URN-3:RAD.SCHL:101557499?manifestVersion=2&prod=1",
 			"version3": "/api/mps?urn=URN-3:RAD.SCHL:101557499?manifestVersion=3&prod=1",
+			"nrs": "/api/nrs/?urn=URN-3:RAD.SCHL:101557499&prod=1",
 			"title": "National Organization for Women Newsletter Collection. New York. Nassau County chapter. Nassau NOW Times. Pr-1.",
 			"owner": "Radcliffe Institute",
 			"type": "page-turned object",
@@ -131,6 +139,7 @@
 		{
 			"version2": "/api/mps?urn=urn-3:FHCL.JUD:40308070?manifestVersion=2&prod=1",
 			"version3": "/api/mps?urn=urn-3:FHCL.JUD:40308070?manifestVersion=3&prod=1",
+			"nrs": "/api/nrs/?urn=urn-3:FHCL.JUD:40308070&prod=1",
 			"title": "Agor, Ya'akov, Israeli. Muze'on ha-ketav in Acre, Israel. 1960 - 1970.",
 			"owner": "Judaica Division, Widener Library",
 			"type": "single image",
@@ -140,6 +149,7 @@
 		{
 			"version2": "/api/mps?urn=urn-3:KSG.LIBR:40505153?manifestVersion=2&prod=1",
 			"version3": "/api/mps?urn=urn-3:KSG.LIBR:40505153?manifestVersion=3&prod=1",
+			"nrs": "/api/nrs/?urn=urn-3:KSG.LIBR:40505153&prod=1",
 			"title": "Krivokhizha, V. I. (VasiliÄ­ Iosifovich), 1947- Russia's national security policy, conceptions and realities.",
 			"owner": "Kennedy School Library",
 			"type": "single image",
@@ -149,6 +159,7 @@
 		{
 			"version2": "/api/mps?urn=urn-3:FHCL.HOUGH:41301981?manifestVersion=2&prod=1",
 			"version3": "/api/mps?urn=urn-3:FHCL.HOUGH:41301981?manifestVersion=3&prod=1",
+			"nrs": "/api/nrs/?urn=urn-3:FHCL.HOUGH:41301981&prod=1",
 			"title": "Thomas Prince journal, 1710-1751. MS Am 3039.",
 			"owner": "Houghton Library",
 			"type": "single image",
@@ -158,6 +169,7 @@
 		{
 			"version2": "/api/mps?urn=urn-3:DOAK.RESLIB:40977022?manifestVersion=2&prod=1",
 			"version3": "/api/mps?urn=urn-3:DOAK.RESLIB:40977022?manifestVersion=3&prod=1",
+			"nrs": "/api/nrs/?urn=urn-3:DOAK.RESLIB:40977022&prod=1",
 			"title": "Nativity. Church of Panagia tou Arakos, nave, west bay, south side, vault, wall paintings, Lagoudera, Cyprus, 1192.",
 			"owner": "Dumbarton Oaks Research Library",
 			"type": "single image",

--- a/env-example.txt
+++ b/env-example.txt
@@ -19,3 +19,12 @@ MPS_MANIFEST_BASEURL=https://mps.lib.harvard.edu/iiif
 # This is used as an override to allow all environments to use Production MPS.
 # Defaults to https://mps.lib.harvard.edu/iiif
 MPS_MANIFEST_PRODURL=https://mps.lib.harvard.edu/iiif
+
+# Set base url for the NRS (Name Resolution Service) for specific environments(optional).  
+# Defaults to https://nrs.harvard.edu
+NRS_BASEURL=https://nrs.harvard.edu
+
+# Set this to the NRS URL for production. 
+# This is used as an override to allow all environments to use Production NRS.
+# Defaults to https://nrs.harvard.edu
+NRS_PRODURL=https://nrs.harvard.edu

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "body-parser": "^1.20.1",
         "bootstrap": "^4.6.0",
         "cookie-parser": "^1.4.5",
+        "cors": "^2.8.5",
         "express": "^4.18.2",
         "express-validator": "^6.12.2",
         "jest-coverage-badges-ts": "^0.1.4",
@@ -1680,6 +1681,18 @@
       "version": "2.1.4",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -3791,6 +3804,14 @@
       "version": "2.2.7",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/object-hash": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "body-parser": "^1.20.1",
     "bootstrap": "^4.6.0",
     "cookie-parser": "^1.4.5",
+    "cors": "^2.8.5",
     "express": "^4.18.2",
     "express-validator": "^6.12.2",
     "jest-coverage-badges-ts": "^0.1.4",

--- a/views/index.eta
+++ b/views/index.eta
@@ -27,6 +27,9 @@
             <% if (mpsExample.version3) { %>
               <li><a href="<%= mpsExample.version3 %>" class="font-weight-light">Version 3</a></li>
             <% } %>
+            <% if (mpsExample.nrs) { %>
+              <li><a href="<%= mpsExample.nrs %>" class="font-weight-light">NRS</a></li>
+            <% } %>
           </ul>
         </div>
         <% }) %>
@@ -48,6 +51,9 @@
               <% } %>
               <% if (idsExample.version3) { %>
                 <li><a href="<%= idsExample.version3 %>" class="font-weight-light">Version 3</a></li>
+              <% } %>
+              <% if (idsExample.nrs) { %>
+                <li><a href="<%= mpsExample.nrs %>" class="font-weight-light">NRS</a></li>
               <% } %>
             </ul>
           </div>


### PR DESCRIPTION
**Adding new nrs route and updating examples.**
* * *

**JIRA Ticket**: [LTSVIEWER-261](https://jira.huit.harvard.edu/browse/LTSVIEWER-261)

# What does this Pull Request do?
This adds a new route at /api/nrs/. It allows you to pass in a URN and then it uses NRS to get the IIIF Manifest and Viewer. At this time NRS will always return a Mirador 2 Viewer.

# How should this be tested?

A description of what steps someone could take to:
* Add the new `NRS_BASEURL` and `NRS_PRODURL` variables to your `.env` using the example file as a guide.
* Set `MPS_MANIFEST_BASEURL` to the desired environment.
* Update your `example-items.json` file using the desired environment.
* Bring up mps-embed using the `LTSVIEWER-261` branch.
* Go to the homepage and confirm that the new NRS links for each item bring up a working embed json response. The IIIF Manifest and Viewer should both be using NRS.
* Repeat the steps for other environments.


# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@f8f8ff @enriquediaz 