### PR TITLE
Changing NRS viewer links to use :VIEW. Removing non-production NRS links.

### DIFF
--- a/config/example-items-dev.json
+++ b/config/example-items-dev.json
@@ -59,7 +59,6 @@
 	"mpsExamples": [{
 			"version2": "/api/mps?urn=URN-3:HUL.OIS:101114808&manifestVersion=2",
 			"version3": "/api/mps?urn=URN-3:HUL.OIS:101114808&manifestVersion=3",
-			"nrs": "/api/nrs/?urn=URN-3:HUL.OIS:101114808",
 			"title": "Society for Basic Irreproducible Research, 010098243-METS.",
 			"owner": "Test item (no owner)",
 			"type": "page-turned object",
@@ -69,7 +68,6 @@
 		{
 			"version2": "/api/mps?urn=URN-3:HUL.OIS:101114812&manifestVersion=2",
 			"version3": "/api/mps?urn=URN-3:HUL.OIS:101114812&manifestVersion=3",
-			"nrs": "/api/nrs/?urn=URN-3:HUL.OIS:101114812",
 			"title": "Society for Basic Irreproducible Research, 008971542_v001-METS.",
 			"owner": "Test item (no owner)",
 			"type": "page-turned object",
@@ -79,7 +77,6 @@
 		{
 			"version2": "/api/mps?urn=URN-3:HUL.OIS:101114810&manifestVersion=2",
 			"version3": "/api/mps?urn=URN-3:HUL.OIS:101114810&manifestVersion=3",
-			"nrs": "/api/nrs/?urn=URN-3:HUL.OIS:101114810",
 			"title": "Society for Basic Irreproducible Research, 008106825_v001-METS.",
 			"owner": "Test item (no owner)",
 			"type": "page-turned object",
@@ -89,7 +86,6 @@
 		{
 			"version2": "/api/mps?urn=URN-3:HUL.OIS:1254672&manifestVersion=2",
 			"version3": "/api/mps?urn=URN-3:HUL.OIS:1254672&manifestVersion=3",
-			"nrs": "/api/nrs/?urn=URN-3:HUL.OIS:1254672",
 			"title": "2000 node test pds object",
 			"owner": "Test item (no owner)",
 			"type": "page-turned object",

--- a/config/example-items-qa.json
+++ b/config/example-items-qa.json
@@ -59,7 +59,6 @@
 	"mpsExamples": [{
 			"version2": "/api/mps?urn=URN-3:HUL.GUEST:409464&manifestVersion=2",
 			"version3": "/api/mps?urn=URN-3:HUL.GUEST:409464&manifestVersion=3",
-			"nrs": "/api/nrs/?urn=URN-3:HUL.GUEST:409464",
 			"title": "Mosquito brigades and how to organize them.",
 			"owner": "Test item (no owner)",
 			"type": "page-turned object",
@@ -69,7 +68,6 @@
 		{
 			"version2": "/api/mps?urn=URN-3:HUL.OIS:100102314&manifestVersion=2",
 			"version3": "/api/mps?urn=URN-3:HUL.OIS:100102314&manifestVersion=3",
-			"nrs": "/api/nrs/?urn=URN-3:HUL.OIS:100102314",
 			"title": "Da Qing jin shen quan shu (Tongzhi jiu nian geng wu xia ji) cc Jingdu Rong lu tang Tongzhi 9 [1870].",
 			"owner": "Test item (no owner)",
 			"type": "page-turned object",
@@ -79,7 +77,6 @@
 		{
 			"version2": "/api/mps?urn=URN-3:GSE.LIBR:100041477&manifestVersion=2",
 			"version3": "/api/mps?urn=URN-3:GSE.LIBR:100041477&manifestVersion=3",
-			"nrs": "/api/nrs/?urn=URN-3:GSE.LIBR:100041477",
 			"title": "North Carolina teachers record. Raleigh, N.C. North Carolina Teachers Association. Volume 37. No. 3. May 1967. ",
 			"owner": "Wilson Library, University of North Carolina Chapel Hill, Black Teacher Archive",
 			"type": "page-turned object",
@@ -89,7 +86,6 @@
 		{
 			"version2": "/api/mps?urn=URN-3:GSE.LIBR:100037458&manifestVersion=2",
 			"version3": "/api/mps?urn=URN-3:GSE.LIBR:100037458&manifestVersion=3",
-			"nrs": "/api/nrs/?urn=URN-3:GSE.LIBR:100037458",
 			"title": "North Carolina teachers record. Raleigh, N.C. North Carolina Teachers Association. Volume 23. No. 2. Mar. 1952.",
 			"owner": "Wilson Library, University of North Carolina Chapel Hill, Black Teacher Archive",
 			"type": "page-turned object",

--- a/routes/api.js
+++ b/routes/api.js
@@ -201,7 +201,7 @@ router.get('/nrs', async function(req, res, next) {
   let currentWidth=1200;
   let currentHeight=700; 
   let manifestId = nrsBaseUrl+'/'+urn+':MANIFEST';
-  let viewerUrl = nrsBaseUrl+'/'+urn+':VIEWER';
+  let viewerUrl = nrsBaseUrl+'/'+urn+':VIEW';
   let manifestResponse, manifestData;
 
   try {


### PR DESCRIPTION
**Changing NRS viewer links to use :VIEW. Removing non-production NRS links.**
* * *

**JIRA Ticket**: [LTSVIEWER-261](https://jira.huit.harvard.edu/browse/LTSVIEWER-261)

# What does this Pull Request do?
Since the IDS / PDS environments are unstable in Dev and QA, the "NRS" links for items have been removed for those environments. The link only shows up for MPS examples tagged as "Prod". This also updates the NRS viewer URLs to use `:VIEW` instead of `:VIEWER`.

# How should this be tested?

A description of what steps someone could take to:
* Rebuild mps-embed off of the `LTSVIEWER-261b` branch with either the dev or qa example file.
* Confirm that "NRS" links only show up for MPS Examples tagged as "Prod"
* Confirm that the viewerUrl link for NRS examples use `:VIEW` at the end of the URL. Clicking on the link should open the object in the old Mirador 2 Viewer. Example: "https://nrs.harvard.edu/URN-3:DIV.LIB:29999858:VIEW"
* 
# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@f8f8ff @enriquediaz 