### PR TITLE
Forcing height and width to always be 100%.

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -13,8 +13,8 @@ const viewerServer = process.env.VIEWER_SERVER;
 router.get('/legacy', async function(req, res, next) {
   
   let recordIdentifier = req.query.recordIdentifier;
-  let currentWidth=1200;
-  let currentHeight=700;
+  let currentWidth='100%';
+  let currentHeight='100%';
   const viewerUrl = new URL(`https://${viewerServer}/viewer/`);
 
   let data, result = {};
@@ -44,8 +44,8 @@ router.get('/legacy', async function(req, res, next) {
 
   consoleLogger.debug('width: '+req.query.width);
   consoleLogger.debug('height: '+req.query.height);
-  currentWidth = dimensionsCtrl.getDimension(req.query.width, currentWidth);
-  currentHeight = dimensionsCtrl.getDimension(req.query.height, currentHeight);
+  currentWidth = dimensionsCtrl.getDimension('100%', currentWidth);
+  currentHeight = dimensionsCtrl.getDimension('100%', currentHeight);
   
   res.json( 
     {
@@ -55,8 +55,6 @@ router.get('/legacy', async function(req, res, next) {
       title: data.title,
       iiif_manifest: manifestId,
       viewerUrl: viewerUrl,
-      height: currentHeight,
-      width: currentWidth,
       html: "\u003ciframe src='"+viewerUrl+"' height='"+currentHeight+"' width='"+currentWidth+"' title='"+data.title+"' frameborder='0' marginwidth='0' marginheight='0' scrolling='no' allowfullscreen\u003e\u003c/iframe\u003e"
     }
   );
@@ -76,8 +74,8 @@ router.get('/mps', async function(req, res, next) {
   consoleLogger.debug(`urn ${urn} manifestVersion ${manifestVersion}`);
 
   let manifestId, manifestResponse, manifestData;
-  let currentWidth=1200;
-  let currentHeight=700;
+  let currentWidth='100%';
+  let currentHeight='100%';
 
   try {
     manifestId = await mpsManifestsCtrl.getManifestId(urn, manifestVersion, productionOverride);
@@ -102,8 +100,8 @@ router.get('/mps', async function(req, res, next) {
 
   consoleLogger.debug('width: '+req.query.width);
   consoleLogger.debug('height: '+req.query.height);
-  currentWidth = dimensionsCtrl.getDimension(req.query.width, currentWidth);
-  currentHeight = dimensionsCtrl.getDimension(req.query.height, currentHeight); 
+  currentWidth = dimensionsCtrl.getDimension('100%', currentWidth);
+  currentHeight = dimensionsCtrl.getDimension('100%', currentHeight);
   
   res.json( 
     {
@@ -113,8 +111,6 @@ router.get('/mps', async function(req, res, next) {
       title: title,
       iiif_manifest: manifestId,
       viewerUrl: viewerUrl,
-      height: currentHeight,
-      width: currentWidth,
       html: "\u003ciframe src='"+viewerUrl+"' height='"+currentHeight+"' width='"+currentWidth+"' title='"+title+"' frameborder='0' marginwidth='0' marginheight='0' scrolling='no' allowfullscreen\u003e\u003c/iframe\u003e"
     }
   );
@@ -132,8 +128,8 @@ router.get('/manifest', async function(req, res, next) {
   consoleLogger.debug(`manifestId ${manifestId}`);
 
   let manifestResponse, manifestData;
-  let currentWidth=1200;
-  let currentHeight=700;
+  let currentWidth='100%';
+  let currentHeight='100%';
 
   try {
     manifestResponse = await mpsManifestsCtrl.getManifest(manifestId);
@@ -152,8 +148,8 @@ router.get('/manifest', async function(req, res, next) {
 
   consoleLogger.debug('width: '+req.query.width);
   consoleLogger.debug('height: '+req.query.height);
-  currentWidth = dimensionsCtrl.getDimension(req.query.width, currentWidth);
-  currentHeight = dimensionsCtrl.getDimension(req.query.height, currentHeight); 
+  currentWidth = dimensionsCtrl.getDimension('100%', currentWidth);
+  currentHeight = dimensionsCtrl.getDimension('100%', currentHeight); 
   
   res.json( 
     {
@@ -163,8 +159,6 @@ router.get('/manifest', async function(req, res, next) {
       title: title,
       iiif_manifest: manifestId,
       viewerUrl: viewerUrl,
-      height: currentHeight,
-      width: currentWidth,
       html: "\u003ciframe src='"+viewerUrl+"' height='"+currentHeight+"' width='"+currentWidth+"' title='"+title+"' frameborder='0' marginwidth='0' marginheight='0' scrolling='no' allowfullscreen\u003e\u003c/iframe\u003e"
     }
   );
@@ -181,8 +175,8 @@ router.get('/nrs', async function(req, res, next) {
   consoleLogger.debug("api.js /manifest");
   consoleLogger.debug(`urn ${urn}`);
 
-  let currentWidth=1200;
-  let currentHeight=700; 
+  let currentWidth='100%';
+  let currentHeight='100%'; 
   let manifestId = nrsBaseUrl+'/'+urn+':MANIFEST';
   let viewerUrl = nrsBaseUrl+'/'+urn+':VIEW';
   let manifestResponse, manifestData;
@@ -206,8 +200,6 @@ router.get('/nrs', async function(req, res, next) {
       title: title,
       iiif_manifest: manifestId,
       viewerUrl: viewerUrl,
-      height: currentHeight,
-      width: currentWidth,
       html: "\u003ciframe src='"+viewerUrl+"' height='"+currentHeight+"' width='"+currentWidth+"' title='"+title+"' frameborder='0' marginwidth='0' marginheight='0' scrolling='no' allowfullscreen\u003e\u003c/iframe\u003e"
     }
   );


### PR DESCRIPTION
**Forcing height and width to always be 100%.**
* * *

**JIRA Ticket**: [LTSVIEWER-274](https://at-harvard.atlassian.net/browse/LTSVIEWER-274)

# What does this Pull Request do?
This forces embed to always return the iframe with height and width set to 100%.

# How should this be tested?

A description of what steps someone could take to:
* Rebuild `mps-embed` using the `LTSVIEWER-274` branch.
* Click on any link on the homepage.
* The `height` and `width` elements in the JSON response are no longer displayed, since they are no longer variable.
* The iframe tag `height` and `width` are all set to 100%
* Even if you put height= or width= in the URL string, the iframe still only returns height=100% and width=100%
* The Unit tests for dimensions and heights still pass. In the container you can run `npm run test` and see them all pass.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? Yes
- integration tests? No

# Interested parties
@enriquediaz @f8f8ff 