### PR TITLE
Adding unique name to the iframe of each endpoint.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,9 @@ dist
 # TernJS port file
 .tern-port
 
+# Bash History
+.bash_history
+
 .idea/
 .DS_Store
 

--- a/routes/api.js
+++ b/routes/api.js
@@ -55,7 +55,7 @@ router.get('/legacy', async function(req, res, next) {
       title: data.title,
       iiif_manifest: manifestId,
       viewerUrl: viewerUrl,
-      html: "\u003ciframe src='"+viewerUrl+"' height='"+currentHeight+"' width='"+currentWidth+"' title='"+data.title+"' frameborder='0' marginwidth='0' marginheight='0' scrolling='no' allowfullscreen\u003e\u003c/iframe\u003e"
+      html: "\u003ciframe name='mps-embed-legacy' src='"+viewerUrl+"' height='"+currentHeight+"' width='"+currentWidth+"' title='"+data.title+"' frameborder='0' marginwidth='0' marginheight='0' scrolling='no' allowfullscreen\u003e\u003c/iframe\u003e"
     }
   );
 
@@ -111,7 +111,7 @@ router.get('/mps', async function(req, res, next) {
       title: title,
       iiif_manifest: manifestId,
       viewerUrl: viewerUrl,
-      html: "\u003ciframe src='"+viewerUrl+"' height='"+currentHeight+"' width='"+currentWidth+"' title='"+title+"' frameborder='0' marginwidth='0' marginheight='0' scrolling='no' allowfullscreen\u003e\u003c/iframe\u003e"
+      html: "\u003ciframe name='mps-embed-mps' src='"+viewerUrl+"' height='"+currentHeight+"' width='"+currentWidth+"' title='"+title+"' frameborder='0' marginwidth='0' marginheight='0' scrolling='no' allowfullscreen\u003e\u003c/iframe\u003e"
     }
   );
 
@@ -159,7 +159,7 @@ router.get('/manifest', async function(req, res, next) {
       title: title,
       iiif_manifest: manifestId,
       viewerUrl: viewerUrl,
-      html: "\u003ciframe src='"+viewerUrl+"' height='"+currentHeight+"' width='"+currentWidth+"' title='"+title+"' frameborder='0' marginwidth='0' marginheight='0' scrolling='no' allowfullscreen\u003e\u003c/iframe\u003e"
+      html: "\u003ciframe name='mps-embed-manifest' src='"+viewerUrl+"' height='"+currentHeight+"' width='"+currentWidth+"' title='"+title+"' frameborder='0' marginwidth='0' marginheight='0' scrolling='no' allowfullscreen\u003e\u003c/iframe\u003e"
     }
   );
 
@@ -200,7 +200,7 @@ router.get('/nrs', async function(req, res, next) {
       title: title,
       iiif_manifest: manifestId,
       viewerUrl: viewerUrl,
-      html: "\u003ciframe src='"+viewerUrl+"' height='"+currentHeight+"' width='"+currentWidth+"' title='"+title+"' frameborder='0' marginwidth='0' marginheight='0' scrolling='no' allowfullscreen\u003e\u003c/iframe\u003e"
+      html: "\u003ciframe name='mps-embed-nrs' src='"+viewerUrl+"' height='"+currentHeight+"' width='"+currentWidth+"' title='"+title+"' frameborder='0' marginwidth='0' marginheight='0' scrolling='no' allowfullscreen\u003e\u003c/iframe\u003e"
     }
   );
 


### PR DESCRIPTION
**Adding unique name to the iframe of each endpoint.**
* * *

**JIRA Ticket**: [LTSVIEWER-280](https://at-harvard.atlassian.net/browse/LTSVIEWER-280)


# What does this Pull Request do?
This adds a unique name to the `<iframe>` tag for each endpoint. 

- mps endpoint: `mps-embed-mps`
- legacy endpoint: `mps-embed-legacy`
- manifest endpoint: `mps-embed-manifest`
- nrs endpoint: `mps-embed-nrs`

# How should this be tested?

A description of what steps someone could take to:
* Rebuild mps-embed off of the `LTSVIEWER-280` branch
* Go to any of the mps links on the homepage (can be either Version 2 or Version 3)
* View the source and confirm the `<iframe>` tag has the `name='mps-embed-mps'` attribute.
* Go to any of the legacy links on the homepage
* View the source and confirm the `<iframe>` tag has the `name='mps-embed-legacy'` attribute.
* * Go to any of the nrs links on the homepage
* View the source and confirm the `<iframe>` tag has the `name='mps-embed-nrs'` attribute.
* Go to a manifest example (such as https://localhost:23018/api/manifest?manifestId=https://mps-qa.lib.harvard.edu/iiif/3/URN-3:HUL.GUEST:409464)
* View the source and confirm the `<iframe>` tag has the `name='mps-embed-manifest'` attribute.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@f8f8ff @enriquediaz 