### PR TITLE
Adding sequence variable to NRS endpoint. Updating Examples.

### DIFF
--- a/config/example-items-dev.json
+++ b/config/example-items-dev.json
@@ -103,6 +103,14 @@
 			"environment": "PROD"
 		},
 		{
+			"nrs": "/api/nrs/?urn=urn-3:FMUS.ARN:37536095&prod=1&n=3",
+			"title": "Plate 3. Epimedium grandiflorum ; Alfred Riocreux botanical watercolors.",
+			"owner": "Botany Libraries",
+			"type": "page-turned object",
+			"size": "96 pages",
+			"environment": "PROD"
+		},
+		{
 			"version2": "/api/mps?urn=URN-3:HLS.LIBR:102621314&manifestVersion=2&prod=1",
 			"version3": "/api/mps?urn=URN-3:HLS.LIBR:102621314&manifestVersion=3&prod=1",
 			"nrs": "/api/nrs/?urn=URN-3:HLS.LIBR:102621314&prod=1",

--- a/config/example-items-prod.json
+++ b/config/example-items-prod.json
@@ -67,6 +67,14 @@
 			"environment": "PROD"
 		},
 		{
+			"nrs": "/api/nrs/?urn=urn-3:FMUS.ARN:37536095&prod=1&n=3",
+			"title": "Plate 3. Epimedium grandiflorum ; Alfred Riocreux botanical watercolors.",
+			"owner": "Botany Libraries",
+			"type": "page-turned object",
+			"size": "96 pages",
+			"environment": "PROD"
+		},
+		{
 			"version2": "/api/mps?urn=URN-3:HLS.LIBR:102621314&manifestVersion=2",
 			"version3": "/api/mps?urn=URN-3:HLS.LIBR:102621314&manifestVersion=3",
 			"nrs": "/api/nrs/?urn=URN-3:HLS.LIBR:102621314",

--- a/config/example-items-qa.json
+++ b/config/example-items-qa.json
@@ -103,6 +103,14 @@
 			"environment": "PROD"
 		},
 		{
+			"nrs": "/api/nrs/?urn=urn-3:FMUS.ARN:37536095&prod=1&n=3",
+			"title": "Plate 3. Epimedium grandiflorum ; Alfred Riocreux botanical watercolors.",
+			"owner": "Botany Libraries",
+			"type": "page-turned object",
+			"size": "96 pages",
+			"environment": "PROD"
+		},
+		{
 			"version2": "/api/mps?urn=URN-3:HLS.LIBR:102621314&manifestVersion=2&prod=1",
 			"version3": "/api/mps?urn=URN-3:HLS.LIBR:102621314&manifestVersion=3&prod=1",
 			"nrs": "/api/nrs/?urn=URN-3:HLS.LIBR:102621314&prod=1",

--- a/routes/api.js
+++ b/routes/api.js
@@ -178,7 +178,9 @@ router.get('/nrs', async function(req, res, next) {
 
   let sequenceViewString = '';
   if (sequence) {
-    sequenceViewString = '?n='+sequence;
+    if (Number.isInteger(parseFloat(sequence))) {
+      sequenceViewString = '?n='+sequence;
+    }
   }
   let currentWidth='100%';
   let currentHeight='100%'; 

--- a/routes/api.js
+++ b/routes/api.js
@@ -171,14 +171,19 @@ router.get('/nrs', async function(req, res, next) {
 
   const urn = req.query.urn;
   const productionOverride = req.query.prod;
+  const sequence = req.query.n;
   const nrsBaseUrl  = (productionOverride == 1) ? process.env.NRS_PRODURL : process.env.NRS_BASEURL || `https://nrs.harvard.edu`;
   consoleLogger.debug("api.js /manifest");
   consoleLogger.debug(`urn ${urn}`);
 
+  let sequenceViewString = '';
+  if (sequence) {
+    sequenceViewString = '?n='+sequence;
+  }
   let currentWidth='100%';
   let currentHeight='100%'; 
   let manifestId = nrsBaseUrl+'/'+urn+':MANIFEST';
-  let viewerUrl = nrsBaseUrl+'/'+urn+':VIEW';
+  let viewerUrl = nrsBaseUrl+'/'+urn+':VIEW'+sequenceViewString;
   let manifestResponse, manifestData;
 
   try {


### PR DESCRIPTION
**Adding sequence variable to NRS endpoint. Updating Examples.**
* * *

# What does this Pull Request do?
This adds the ability to add the sequence request variable (`n`) to the nrs embed call. This is for legacy viewer only. This will bring back pre-existing functionality in CURIOSity that had item pages display a particular sequence of an object in the viewer.

# How should this be tested?

A description of what steps someone could take to:
* Replace your examples-item.json file with the new one that is appropriate for your current local environment (dev/qa/prod). This adds a new Botanical item that goes to page 3.
* Build mps-embed off of the fix-sequence branch.
* Click on the NRS link of new Botanical item on the homepage (Plate 3. Epimedium grandiflorum ; Alfred Riocreux botanical watercolors.) and confirm the viewer contains the `n` variable with the value of 3 ("https://nrs.harvard.edu/urn-3:FMUS.ARN:37536095:VIEW?n=3")
* Click on the vieweUrl and confirm that Plate 3 is displayed in the legacy viewer.
* You can change the `n` variable in the url with any other valid sequence number and it will display that plate in the viewer. (example: https://localhost:23018/api/nrs/?urn=urn-3:FMUS.ARN:37536095&prod=1&n=9)
* You can also do the same for any other page turned object.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz @f8f8ff 